### PR TITLE
Change Cpi.Pins reference to Pins reference.

### DIFF
--- a/Samples/Netduino/GlitchFilter/index.md
+++ b/Samples/Netduino/GlitchFilter/index.md
@@ -18,7 +18,7 @@ namespace GlitchFilter
 		// An output port allows you to write (send a signal) to a pin
 		static OutputPort _led = new OutputPort(Pins.ONBOARD_LED, false);
 		// An input port reads the signal from a pin (Should be Pins.ONBOARD_BTN, but there is a bug)
-		static InputPort _button = new InputPort((Cpu.Pin)0x15, true, Port.ResistorMode.Disabled);
+		static InputPort _button = new InputPort(Pins.ONBOARD_SW1, true, Port.ResistorMode.Disabled);
 
 		public static void Main()
 		{
@@ -26,8 +26,7 @@ namespace GlitchFilter
 			_led.Write(false);
 
 			// smooth noise out over 5 milliseconds
-			Cpu.GlitchFilterTime = new TimeSpan(0,0,0,0,5);
-
+			Cpu.GlitchFilterTime = new TimeSpan(0, 0, 0, 0, 5);
 
 			// run forever
 			while (true)


### PR DESCRIPTION
Changed the pin enum used to reference the onboard switch.

Two different Pins enums were used - Pins and Cpu.Pins.  Changed the InputPort to use the Pins enum for consistency.  Also, end users should really be using the pins enum.