### PR TITLE
Add more localhost install steps and tweak some Markdown formatting

### DIFF
--- a/Netduino/Getting_Started/index.md
+++ b/Netduino/Getting_Started/index.md
@@ -39,21 +39,22 @@ Once your development environment is configured, make sure your board has the la
  1. Launch Visual Studio and create a new solution of type **Visual C# > Micro Framework > Console Application** and name it whatever you want:
  ![New Solution Dialog](02-New_Solution_VS.png)
  
-2. Right-click on the **References** folder in the Solution Explorer and add:
- 	* Microsoft.Spot.Hardware
- 	* SecretLabs.NETMF.Hardware
- 	* SecretLabs.NETMF.Harware.Netduino (or NetduinoPlus if that's what you're using)
+ 2. Right-click on the **References** folder in the Solution Explorer and add:
+ 
+     * Microsoft.Spot.Hardware
+     * SecretLabs.NETMF.Hardware
+     * SecretLabs.NETMF.Harware.Netduino (or NetduinoPlus if that's what you're using)
 
 ### Xamarin Studio
 
- 1. Launch Xamarin Studio and create a new solution of type **C# > MicroFramework > MicroFramework Console Applicaiton** and name it whatever you want:
+ 1. Launch Xamarin Studio and create a new solution of type **C# > MicroFramework > MicroFramework Console Application** and name it whatever you want:
 ![New Solution Dialog](01-NewSolution_XS.png)
 
  2. Double-click on the **References** folder in the Solution Pad and add:
- 	* Microsoft.Spot.Hardware
- 	* SecretLabs.NETMF.Hardware
- 	* SecretLabs.NETMF.Harware.Netduino (or NetduinoPlus if that's what you're using)
-
+ 
+    * Microsoft.Spot.Hardware
+    * SecretLabs.NETMF.Hardware
+    * SecretLabs.NETMF.Harware.Netduino (or NetduinoPlus if that's what you're using)
 
 ### Add the Code
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,24 @@ To browse locally:
 ### 1. [Install Homebrew](https://brew.sh/) (if not already installed).
 
 
-### 2. Install Ruby:
+### 2. Install prerequisites: Ruby, Jekyll, Bundler, and various gems
+
 Open a terminal and run:
 
 ```
 $ brew install ruby
+```
+
+Once you have Ruby, you'll need Jekyll and Bundler to build and host the site locally:
+
+```
+$ gem install jekyll bundler
+```
+
+With the Bundler installed to manage the Ruby gems, you can run a command to install all the prerequisite gems for the site:
+
+```
+$ bundle install
 ```
 
 ### 3. Launch local server

--- a/_site/Netduino/Getting_Started/index.html
+++ b/_site/Netduino/Getting_Started/index.html
@@ -316,10 +316,13 @@
  <img src="02-New_Solution_VS.png" alt="New Solution Dialog" /></p>
   </li>
   <li>
-    <p>Right-click on the <strong>References</strong> folder in the Solution Explorer and add:
- 	* Microsoft.Spot.Hardware
- 	* SecretLabs.NETMF.Hardware
- 	* SecretLabs.NETMF.Harware.Netduino (or NetduinoPlus if that’s what you’re using)</p>
+    <p>Right-click on the <strong>References</strong> folder in the Solution Explorer and add:</p>
+
+    <ul>
+      <li>Microsoft.Spot.Hardware</li>
+      <li>SecretLabs.NETMF.Hardware</li>
+      <li>SecretLabs.NETMF.Harware.Netduino (or NetduinoPlus if that’s what you’re using)</li>
+    </ul>
   </li>
 </ol>
 
@@ -327,14 +330,17 @@
 
 <ol>
   <li>
-    <p>Launch Xamarin Studio and create a new solution of type <strong>C# &gt; MicroFramework &gt; MicroFramework Console Applicaiton</strong> and name it whatever you want:
+    <p>Launch Xamarin Studio and create a new solution of type <strong>C# &gt; MicroFramework &gt; MicroFramework Console Application</strong> and name it whatever you want:
 <img src="01-NewSolution_XS.png" alt="New Solution Dialog" /></p>
   </li>
   <li>
-    <p>Double-click on the <strong>References</strong> folder in the Solution Pad and add:
- 	* Microsoft.Spot.Hardware
- 	* SecretLabs.NETMF.Hardware
- 	* SecretLabs.NETMF.Harware.Netduino (or NetduinoPlus if that’s what you’re using)</p>
+    <p>Double-click on the <strong>References</strong> folder in the Solution Pad and add:</p>
+
+    <ul>
+      <li>Microsoft.Spot.Hardware</li>
+      <li>SecretLabs.NETMF.Hardware</li>
+      <li>SecretLabs.NETMF.Harware.Netduino (or NetduinoPlus if that’s what you’re using)</li>
+    </ul>
   </li>
 </ol>
 


### PR DESCRIPTION
Initially just adjusting Markdown to get some bulleted lists to render correctly on the [Getting Started page](http://developer.wildernesslabs.co/Netduino/Getting_Started/#visual-studio), and fix a quick typo.

Once I tried to preview it, though, I couldn't get the site to run locally without a few more steps, so I added the steps I had to follow to get Jekyll to serve locally.

I also committed the resulting Jekyll-generated HTML files, since they were being tracked by Git.

## Preview Markdown changes

Page currently: http://developer.wildernesslabs.co/Netduino/Getting_Started/#visual-studio

After changes:

<img width="569" alt="screen shot 2017-07-28 at 13 51 05" src="https://user-images.githubusercontent.com/713665/28734070-5d767e5a-739c-11e7-8225-df1adf8cefd3.png">
