### PR TITLE
Unify code whitespace

### DIFF
--- a/docs/Netduino/Input_Output/File_Storage/index.md
+++ b/docs/Netduino/Input_Output/File_Storage/index.md
@@ -38,7 +38,7 @@ namespace SDCardIO
 		public static void Main()
 		{
 			// some debug output for funsies 
-			OutputSDInfo ();
+			OutputSDInfo();
 
 			var volume = new VolumeInfo("SD");
 
@@ -49,28 +49,28 @@ namespace SDCardIO
 				var path = Path.Combine("SD","test.txt");
 
 				// write some text to a file
-				File.WriteAllBytes (path, Encoding.UTF8.GetBytes ("Foooooooo"));
+				File.WriteAllBytes(path, Encoding.UTF8.GetBytes("Foooooooo"));
 
 				// Must call flush to write immediately. Otherwise, there's no guarantee 
 				// as to when the file is written. 
 				volume.FlushAll();
 
 			} else {
-				Debug.Print ("There doesn't appear to be an SD card inserted");
+				Debug.Print("There doesn't appear to be an SD card inserted");
 			}
 		}
 
 		public static void OutputSDInfo()
 		{
-			var vInfo = new VolumeInfo ("SD");
+			var vInfo = new VolumeInfo("SD");
 
 			if (vInfo != null) {
-				Debug.Print ("Is Formatted: " + vInfo.IsFormatted.ToString ());
-				Debug.Print ("Total Free Space: " + vInfo.TotalFreeSpace.ToString ());
-				Debug.Print ("Total Size: " + vInfo.TotalSize.ToString ());
-				Debug.Print ("File System: " + vInfo.FileSystem);
+				Debug.Print("Is Formatted: " + vInfo.IsFormatted.ToString ());
+				Debug.Print("Total Free Space: " + vInfo.TotalFreeSpace.ToString ());
+				Debug.Print("Total Size: " + vInfo.TotalSize.ToString ());
+				Debug.Print("File System: " + vInfo.FileSystem);
 			} else {
-				Debug.Print ("There doesn't appear to be an SD card in the device.");
+				Debug.Print("There doesn't appear to be an SD card in the device.");
 			}
 
 		}


### PR DESCRIPTION
There was a mix of `Method()` and `Method ()`, so I made them all match the current default in VS2015 of no space between name and invocation.