### PR TITLE
Fix Displays.Lcd.CharacterDisplay sample

### DIFF
--- a/docfx/api-override/Meadow.Foundation/Meadow.Foundation.Displays.Lcd.CharacterDisplay.md
+++ b/docfx/api-override/Meadow.Foundation/Meadow.Foundation.Displays.Lcd.CharacterDisplay.md
@@ -8,7 +8,7 @@ uid: Meadow.Foundation.Displays.Lcd.CharacterDisplay
 example: [*content]
 ---
 
-The following example shows how print an incrementing counter every second on the LCD display:
+The following example shows how to print an incrementing counter every second on the LCD display:
 
 ```csharp
 using Meadow;
@@ -32,15 +32,22 @@ namespace LedSample
         }
     }
     
-    class CharacterDisplayApp : AppBase<F7Micro, CharacterDisplayApp>
+    class CharacterDisplayApp : App<F7Micro, CharacterDisplayApp>
     {
         CharacterDisplay display;
 
         public CharacterDisplayApp()
         {
-            display = new CharacterDisplay(Device, Device.Pins.D05, Device.Pins.D07,
-                Device.Pins.D08, Device.Pins.D09, Device.Pins.D10, Device.Pins.D11,
-                16, 2);
+            display = new CharacterDisplay(
+                Device,
+                pinRS: Device.Pins.D05,
+                pinE:  Device.Pins.D07,
+                pinD4: Device.Pins.D08,
+                pinD5: Device.Pins.D09,
+                pinD6: Device.Pins.D10,
+                pinD7: Device.Pins.D11,
+                rows: 2, columns: 16    // Adjust dimensions to fit your display
+                );
 
             int count = 0;
             display.WriteLine("CharacterDisplay", 0);


### PR DESCRIPTION
The CharacterDisplay sample doesn't work currently because the last two constructor arguments (rows and columns) are reversed. I've updated it with named arguments to avoid this in future. It also uses AppBase<> instead of App<>.