### PR TITLE
Missing 'docs` from pages.

### DIFF
--- a/docs/Meadow/Getting_Started/Assemble_Meadow/index.md
+++ b/docs/Meadow/Getting_Started/Assemble_Meadow/index.md
@@ -57,4 +57,4 @@ Additionally, you could get metal or nylon fasteners so you screw them in the co
 
 Congratulations, your Meadow developer kit assembled and now you're ready to test the Meadow board on the next section. 
 
-## [Next - Deploy Meadow OS](/Meadow/Getting_Started/Deploying_Meadow/)
+## [Next - Deploy Meadow OS](/docs/Meadow/Getting_Started/Deploying_Meadow/)

--- a/docs/Meadow/Getting_Started/Deploying_Meadow/index.md
+++ b/docs/Meadow/Getting_Started/Deploying_Meadow/index.md
@@ -108,4 +108,4 @@ Your board is now ready to have a Meadow application deployed to it!
  * If you only have one dfu enabled device connected to your PC, you can omit `-S [DEVICE_SERIAL]`.
  * Linux may require `sudo` to access USB devices.
 
-## [Next - Hello, Meadow](/Meadow/Getting_Started/Hello_World/)
+## [Next - Hello, Meadow](/docs/Meadow/Getting_Started/Hello_World/)

--- a/docs/Meadow/Getting_Started/Hello_World/index.md
+++ b/docs/Meadow/Getting_Started/Hello_World/index.md
@@ -252,5 +252,5 @@ public void BlinkLeds()
 
 Now that you understand the basic of a Meadow application, we recommend learning about the following topics:
 
- * [Hardware I/O](/Meadow/Meadow_Basics/IO/)
- * [Meadow.Foundation](/Meadow/Meadow.Foundation/)
+ * [Hardware I/O](/docs/Meadow/Meadow_Basics/IO/)
+ * [Meadow.Foundation](/docs/Meadow/Meadow.Foundation/)

--- a/docs/Meadow/Getting_Started/index.md
+++ b/docs/Meadow/Getting_Started/index.md
@@ -4,6 +4,6 @@ title: Get started with Meadow
 subtitle: "To get up and running with Meadow, follow these steps:"
 ---
 
- 1. [Assemble your Meadow board](/Meadow/Getting_Started/Assemble_Meadow/)
- 2. [Deploy Meadow OS to your Board](/Meadow/Getting_Started/Deploying_Meadow/)
- 3. [Hello, Meadow](/Meadow/Getting_Started/Hello_World/)
+ 1. [Assemble your Meadow board](/docs/Meadow/Getting_Started/Assemble_Meadow/)
+ 2. [Deploy Meadow OS to your Board](/docs/Meadow/Getting_Started/Deploying_Meadow/)
+ 3. [Hello, Meadow](/docs/Meadow/Getting_Started/Hello_World/)

--- a/docs/Meadow/Meadow.Foundation/index.md
+++ b/docs/Meadow/Meadow.Foundation/index.md
@@ -36,14 +36,14 @@ public class HelloBlinky
 }
 ```
 
-**[Get Started with Meadow.Foundation](/Meadow/Meadow.Foundation/Getting_Started)**
+**[Get Started with Meadow.Foundation](/docs/Meadow/Meadow.Foundation/Getting_Started)**
 
 ## Huge Peripheral Driver Library
 
 Meadow.Foundation has built in support for most common sensors, motors, and other peripherals available on the market.
 
-**[See the full peripheral list](/Meadow/Meadow.Foundation/Peripherals)**
+**[See the full peripheral list](/docs/Meadow/Meadow.Foundation/Peripherals)**
 
 ## Powerful Frameworks and Libraries
 
-**[See the full list](/Meadow/Meadow.Foundation/Libraries_and_Frameworks)**
+**[See the full list](/docs/Meadow/Meadow.Foundation/Libraries_and_Frameworks)**

--- a/docs/Meadow/Meadow_Basics/Apps/index.md
+++ b/docs/Meadow/Meadow_Basics/Apps/index.md
@@ -126,4 +126,4 @@ namespace HelloLED
 }
 ```
 
-# [Next - Input/Output](/Meadow/Meadow_Basics/IO/)
+# [Next - Input/Output](/docs/Meadow/Meadow_Basics/IO/)

--- a/docs/Meadow/Meadow_Basics/IO/index.md
+++ b/docs/Meadow/Meadow_Basics/IO/index.md
@@ -116,4 +116,4 @@ IDigitalOutputPort redLED = Device.CreateDigitalOutputPort(Device.Pins.OnboardLe
 
 When building Meadow applications, most of the time, you'll use high-level peripheral drivers via Meadow.Foundation instead of interacting with ports directly, as we'll explore in the next section.
 
-## [Next - Meadow.Foundation](/Meadow/Meadow.Foundation/)
+## [Next - Meadow.Foundation](/docs/Meadow/Meadow.Foundation/)

--- a/docs/Meadow/Meadow_Basics/Status/index.md
+++ b/docs/Meadow/Meadow_Basics/Status/index.md
@@ -6,7 +6,7 @@ subtitle: Guides and documentation for Meadow
 
 # Meadow F7 Micro Beta Status
 
-We are currently in [Meadow Beta 3](/Meadow/Release_Notes/Beta3/).
+We are currently in [Meadow Beta 3](/docs/Meadow/Release_Notes/Beta3/).
 
 ## General IO Features
 
@@ -38,4 +38,4 @@ We are currently in [Meadow Beta 3](/Meadow/Release_Notes/Beta3/).
 | Battery Voltage Level | No | Planed, Beta 4; Relies on Networking co-processor.
 | Power Management APIs | No | Planned for RC-1 |
 
-## [Next - Fundamentals of Meadow Apps](/Meadow/Meadow_Basics/Apps/)
+## [Next - Fundamentals of Meadow Apps](/docs/Meadow/Meadow_Basics/Apps/)

--- a/docs/Meadow/Release_Notes/Beta3/index.md
+++ b/docs/Meadow/Release_Notes/Beta3/index.md
@@ -10,7 +10,7 @@ This is quite a big release with new features, including UART, and a major overh
 
 ### Serial/UART
 
-Meadow now has Serial/UART support! Check out the new [UART guide](/Meadow/Meadow_Basics/IO/Digital/Protocols/UART/) for all the details!
+Meadow now has Serial/UART support! Check out the new [UART guide](/docs/Meadow/Meadow_Basics/IO/Digital/Protocols/UART/) for all the details!
 
 ### Better Digital Protocol Errs
 
@@ -22,7 +22,7 @@ You can now set the speed of the I2C bus. Somehow we missed this when we launche
 
 ### Meadow.CLI Docs
 
-We've published a [guide for the Meadow.CLI (Command Line Interface)](/Meadow/Meadow_Basics/Meadow_CLI/).
+We've published a [guide for the Meadow.CLI (Command Line Interface)](/docs/Meadow/Meadow_Basics/Meadow_CLI/).
 
 ### Meadow.Foundation
 
@@ -136,7 +136,7 @@ To upgrade, you'll need to [flash the latest version of Meadow.OS](/Meadow/Getti
 
 ### Basic Analog Input is Up
 
-We got basic [analog](/Meadow/Meadow_Basics/IO/Analog/) input ports working on pins `A0` through `A3`. To read an analog input value, create an [`AnalogInputPort`](/docs/api/Meadow/Meadow.Hardware.AnalogInputPort.html) on one of those pins and call the [`Read()`](/docs/api/Meadow/Meadow.Hardware.AnalogInputPort.html#Meadow_Hardware_AnalogInputPort_Read_System_Int32_System_Int32_) method. 
+We got basic [analog](/docs/Meadow/Meadow_Basics/IO/Analog/) input ports working on pins `A0` through `A3`. To read an analog input value, create an [`AnalogInputPort`](/docs/api/Meadow/Meadow.Hardware.AnalogInputPort.html) on one of those pins and call the [`Read()`](/docs/api/Meadow/Meadow.Hardware.AnalogInputPort.html#Meadow_Hardware_AnalogInputPort_Read_System_Int32_System_Int32_) method. 
 
 Note that advanced `IObservable` and events do not work at this time.
 
@@ -154,7 +154,7 @@ In order to be compatible with the file system changes, the `Meadow.CLI` has als
 
 ### SPI
 
-We got [SPI](/Meadow/Meadow_Basics/IO/Digital/Protocols/SPI/) validated and merged. We’re excited to get this out, as we know that several of you are working on integrations that require SPI. To use it, you’ll need to flash your Meadow board with the [latest OS firmware binaries](https://www.wildernesslabs.co/downloads?f=/Meadow_Beta/MeadowOS.zip).
+We got [SPI](/docs/Meadow/Meadow_Basics/IO/Digital/Protocols/SPI/) validated and merged. We’re excited to get this out, as we know that several of you are working on integrations that require SPI. To use it, you’ll need to flash your Meadow board with the [latest OS firmware binaries](https://www.wildernesslabs.co/downloads?f=/Meadow_Beta/MeadowOS.zip).
 
 ### Visual Studio Extension
 
@@ -188,7 +188,7 @@ Say hello to productivity! That's right, we now have extensions for [Visual Stud
 
 #### Digital Outputs and Protocols
 
-##### [Pulse-Width-Modulation (PWM)](/Meadow/Meadow_Basics/IO/Digital/PWM/)
+##### [Pulse-Width-Modulation (PWM)](/docs/Meadow/Meadow_Basics/IO/Digital/PWM/)
 
 PWM is now live! Along with it, PwmLed, RgbPwmLed, Servo Core, etc.
 
@@ -200,7 +200,7 @@ IPwmPort pwm = Device.CreatePwmPort(
 pwm.Start();
 ```
 
-##### [Inter-Integrated Circuits (I2C)](/Meadow/Meadow_Basics/IO/Digital/Protocols/I2C/)
+##### [Inter-Integrated Circuits (I2C)](/docs/Meadow/Meadow_Basics/IO/Digital/Protocols/I2C/)
 
 The I2C protocol is also available in our latest Meadow OS.
 
@@ -221,4 +221,4 @@ GY521Test(i2c); // Pass i2c to an I2C capable device
 * Meadow runtime is slow. For instance, we're currently only able to get about 30-40hz out of the `SoftPwmPort`. There's still a lot of debug code, so this will get much faster in future releases.
 * `GlitchFilterCycleCount` is not implemented in `DigitalInputPort`. This is coming soon.
 * [`Debug.Write` calls don't output to the console](https://github.com/WildernessLabs/Meadow_Issues/issues/3) - Workaround is to use `Console.Write` calls.
-* [Serial Peripheral Interface (SPI)](/Meadow/Meadow_Basics/IO/Digital/Protocols/SPI/) - not working as expected, investigating.
+* [Serial Peripheral Interface (SPI)](/docs/Meadow/Meadow_Basics/IO/Digital/Protocols/SPI/) - not working as expected, investigating.

--- a/docs/Meadow/index.md
+++ b/docs/Meadow/index.md
@@ -14,30 +14,30 @@ Also, make sure to join the [Wilderness Labs Slack](http://slackinvite.wildernes
 
 ## Getting Started
 
-If you're just beginning, check out the [Getting Started](/Meadow/Getting_Started) walkthrough to get your development environment configured and deploy your first Meadow application:
+If you're just beginning, check out the [Getting Started](/docs/Meadow/Getting_Started) walkthrough to get your development environment configured and deploy your first Meadow application:
 
- * [Assembling your Meadow board](/Meadow/Getting_Started/Assemble_Meadow)
- * [Deploying Meadow OS](/Meadow/Getting_Started/Deploying_Meadow)
- * [Hello, Meadow](/Meadow/Getting_Started/Hello_World)
+ * [Assembling your Meadow board](/docs/Meadow/Getting_Started/Assemble_Meadow)
+ * [Deploying Meadow OS](/docs/Meadow/Getting_Started/Deploying_Meadow)
+ * [Hello, Meadow](/docs/Meadow/Getting_Started/Hello_World)
 
 ## Meadow Basics
 
-Then continue on to the [Meadow Basics](/Meadow/Meadow_Basics) Guides to learn about the fundamentals of Meadow applications as well as the current beta feature status.
+Then continue on to the [Meadow Basics](/docs/Meadow/Meadow_Basics) Guides to learn about the fundamentals of Meadow applications as well as the current beta feature status.
 
- * [Beta Status](/Meadow/Meadow_Basics/Status)
- * [App Fundamentals](/Meadow/Meadow_Basics/Apps)
- * [Input/Output (IO)](/Meadow/Meadow_Basics/IO)
+ * [Beta Status](/docs/Meadow/Meadow_Basics/Status)
+ * [App Fundamentals](/docs/Meadow/Meadow_Basics/Apps)
+ * [Input/Output (IO)](/docs/Meadow/Meadow_Basics/IO)
 
 ### Roadmap + Release Notes
 
- * [Roadmap](/Meadow/Release_Notes/Roadmap)
- * [Release Notes](/Meadow/Release_Notes)
+ * [Roadmap](/docs/Meadow/Release_Notes/Roadmap)
+ * [Release Notes](/docs/Meadow/Release_Notes)
 
 ## Meadow.Foundation
 
-Finally, check out [Meadow.Foundation](/Meadow/Meadow.Foundation) to learn how it can greatly simplify building connected things.
+Finally, check out [Meadow.Foundation](/docs/Meadow/Meadow.Foundation) to learn how it can greatly simplify building connected things.
 
- * [Getting Started w/Meadow.Foundation](/Meadow/Meadow.Foundation/Getting_Started)
- * [Meadow.Foundation Peripheral Library](/Meadow/Meadow.Foundation/Peripherals)
- * [Unified GPIO Architecture](/Meadow/Meadow.Foundation/Unified_GPIO_Arch)
- * [Meadow.Foundation Libraries and Frameworks](/Meadow/Meadow.Foundation/Libraries_and_Frameworks)
+ * [Getting Started w/Meadow.Foundation](/docs/Meadow/Meadow.Foundation/Getting_Started)
+ * [Meadow.Foundation Peripheral Library](/docs/Meadow/Meadow.Foundation/Peripherals)
+ * [Unified GPIO Architecture](/docs/Meadow/Meadow.Foundation/Unified_GPIO_Arch)
+ * [Meadow.Foundation Libraries and Frameworks](/docs/Meadow/Meadow.Foundation/Libraries_and_Frameworks)


### PR DESCRIPTION
Currently this gives a 404. This PR fixes that for the Meadow pages. There may be more pages that need this update.