### PR TITLE
Correct copy and paste error in servo introduction paragraph

### DIFF
--- a/docfx/api-override/Meadow.Foundation/Meadow.Foundation.Servos.Servo.md
+++ b/docfx/api-override/Meadow.Foundation/Meadow.Foundation.Servos.Servo.md
@@ -91,7 +91,7 @@ Servo cable colors vary by manufacture, but they're always in the same order. Th
 | 2   | VCC     | Red           | Red or Brown    | Red       |
 | 3   | Control | White         | Yellow or White | Orange    |
 
-The following example shows how to initialize a PiezoSpeaker and play a melody using an array of notes:
+The following example shows how to control the movements of a servo:
 
 ```csharp
 public class MeadowApp : App<F7Micro, MeadowApp>


### PR DESCRIPTION
The text from the PiezoSpeaker documentation has been incorrectly used in the servo documentation.