### PR TITLE
*LEDApp

### DIFF
--- a/docs/Meadow/Meadow_Basics/Apps/index.md
+++ b/docs/Meadow/Meadow_Basics/Apps/index.md
@@ -83,7 +83,7 @@ class LEDApp : App<F7Micro, LEDApp>
     private IDigitalOutputPort blueLed;
     private IDigitalOutputPort greenLed;
 
-    public override void Run()
+    public LEDApp()
     {
         CreateOutputs();
         ShowLights();


### PR DESCRIPTION
Changed public override void Run() to public LEDApp().
IApp does not contain a Run() method.
Assembly Meadow, Version 0.13.0.0
Meadow.Foundation (0.15.2)
Device  MeadowOS Version: 0.3.11 (May 22 2020 21:40:16)
