### PR TITLE
typo correction: Foudnation

### DIFF
--- a/docfx/api/Meadow.Foundation/index.md
+++ b/docfx/api/Meadow.Foundation/index.md
@@ -14,7 +14,7 @@ If you're in search of Meadow Guides (not API reference) you can find them [here
 
 Here are some common Meadow.Foundation guides:
 
-* **[Meadow.Foundation Getting Started](/Meadow/Meadow.Foundation/Getting_Started/)** - Beginning guide to working with Meadow.Foudnation.
+* **[Meadow.Foundation Getting Started](/Meadow/Meadow.Foundation/Getting_Started/)** - Beginning guide to working with Meadow.Foundation.
 * **[Meadow.Foundation Peripheral Drivers List](/Meadow/Meadow.Foundation/Peripherals/)** - A comprehensive list of all peripheral drivers in Meadow.Foundation.
 * **[Meadow.Foundation Libraries and Frameworks](/Meadow/Meadow.Foundation/Libraries_and_Frameworks/)** - A list of libraries and frameworks in Meadow.Foundation such as the MicroGraphics and TextDisplayMenu libraries.
 .

--- a/docfx/api/Meadow/index.md
+++ b/docfx/api/Meadow/index.md
@@ -21,7 +21,7 @@ If you're in search of Meadow Guides (not API reference) you can find them [here
 
 Here are some common Meadow.Foundation guides:
 
-* **[Meadow.Foundation Getting Started](/Meadow/Meadow.Foundation/Getting_Started/)** - Beginning guide to working with Meadow.Foudnation.
+* **[Meadow.Foundation Getting Started](/Meadow/Meadow.Foundation/Getting_Started/)** - Beginning guide to working with Meadow.Foundation.
 * **[Meadow.Foundation Peripheral Drivers List](/Meadow/Meadow.Foundation/Peripherals/)** - A comprehensive list of all peripheral drivers in Meadow.Foundation.
 * **[Meadow.Foundation Libraries and Frameworks](/Meadow/Meadow.Foundation/Libraries_and_Frameworks/)** - A list of libraries and frameworks in Meadow.Foundation such as the MicroGraphics and TextDisplayMenu libraries.
 


### PR DESCRIPTION
Discovered a typo while reviewing documentation.  Search found it is two places.
"Foudnation" --> "Foundation"