### PR TITLE
Part 5, Resistive Sensor Lab: Fix page truncation

### DIFF
--- a/docs/Hardware/Tutorials/Electronics/Part5/Resistive_Sensor_Lab/index.md
+++ b/docs/Hardware/Tutorials/Electronics/Part5/Resistive_Sensor_Lab/index.md
@@ -148,7 +148,7 @@ Using that formula, I created the following table of values:
 
 | Light Level Threshold | R1 Value  | Sensor Resistance (R2) | R2 & ADC Resistance | Total R | Vin   | Vout  |
 |-----------------------|-----------|------------------------|---------------------|---------|-------|-------|
-| Bright                | 4.7kΩ     | < 1kΩ                  | 0.9kΩ               | 5.6kΩ   | 3.3V  | 0.53V |
+| Bright                | 4.7kΩ     | < 1kΩ                  | 0.9kΩ               | 5.6kΩ   | 3.3V  | 0.53V |
 | Dark                  | 4.7kΩ     | > 75kΩ                 | 9.6kΩ               | 14.3kΩ  | 3.3V  | 2.2V  |
 
 


### PR DESCRIPTION
As described in #315, I found a weird Unicode character in the table that was breaking the rest of the page from rendering.

After getting local browser working (with PR #314 resulting), I was able to verify the rest of the page being processed into the resulting HTML now. (Though that table's long headers appears to make rendering a challenge, regardless.)

## After PR

![Screenshot of the previously truncated table now containing the rest of the table data and following paragraph.](https://user-images.githubusercontent.com/713665/164108347-f49e52f0-213c-44c0-99c4-82366bafee9e.png)

For a before shot, see the screenshot in #315.

{Fixes #315}