### PR TITLE
Add Application Configuration instructions and options

### DIFF
--- a/docs/Meadow/Meadow.OS/Configuration/index.md
+++ b/docs/Meadow/Meadow.OS/Configuration/index.md
@@ -9,10 +9,10 @@ Meadow has a robust configuration framework that allows you to adjust settings a
 ## OS/Device Configuration and Application Configuration
 
 Meadow.OS support the following configuration sets:
- 
- * **OS & Device Configuration** - Specified in the `meadow.config.yaml` file. Includes general board and system configuration settings.
- * **WiFi Network Credentials** - Specified in the `wifi.config.yaml`. Specifies WiFi access point and password configuration.
- * **Application Configuration** - Specified in `app.config.yaml` or `app.config.json`. Specifies application settings for logging and reboot configuration, but also for custom developer application settings.
+
+* **OS & Device Configuration** - Specified in the `meadow.config.yaml` file. Includes general board and system configuration settings.
+* **WiFi Network Credentials** - Specified in the `wifi.config.yaml`. Specifies WiFi access point and password configuration.
+* **Application Configuration** - Specified in `app.config.yaml` or `app.config.json`. Includes application settings for logging and reboot configuration. Also used for custom developer application settings.
 
 These files are optional and the default values (shown below) will be used if the particular file is missing from the file system.
 
@@ -250,5 +250,5 @@ For an example of configuration in use, see the [Config Files sample App](https:
                 Build this nifty clock for your desk that gives you time and date, along with room and outdoor temperature using a REST service.
             </p>
         </td>
-    </tr>    
+    </tr>
 </table>

--- a/docs/Meadow/Meadow.OS/Configuration/index.md
+++ b/docs/Meadow/Meadow.OS/Configuration/index.md
@@ -12,7 +12,7 @@ Meadow.OS support the following configuration sets:
  
  * **OS & Device Configuration** - Specified in the `meadow.config.yaml` file. Includes general board and system configuration settings.
  * **WiFi Network Credentials** - Specified in the `wifi.config.yaml`. Specifies WiFi access point and password configuration.
- * **Application Configuration** - Specified in `app.config.yaml`. This functionality is coming soon.
+ * **Application Configuration** - Specified in `app.config.yaml` or `app.config.json`. Specifies application settings for logging and reboot configuration, but also for custom developer application settings.
 
 These files are optional and the default values (shown below) will be used if the particular file is missing from the file system.
 
@@ -144,6 +144,71 @@ This file will be processed after the `meadow.config.yaml` file.  The `Ssid` nam
 The `wifi.config.yaml` file will be deleted from flash storage after it has been processed and stored in secure storage on the ESP32 as the information is considered sensitive. This prevents the possibility of the file being read at a later point in time.
 
 The contents of this file along with the `AutomaticallyStartNetwork` value in `meadow.config.yaml` can be used to automatically connect to an access point when the board starts.
+
+## Application Configuration
+
+Either an `appconfig.yaml` or `appconfig.json` file can be used to set application configuration settings. The names are case sensitive. You can you one or the other, or both. If both application configuration files are used, the values in `appconfig.yaml` are applied first and then any values in `appconfig.json` are applied next.
+
+<!-- Confirm appconfig.* case sensitivity -->
+<!-- Confirm behavior of dual config -->
+
+Custom developer-provided application settings can also be included.
+
+### Lifecycle - Automatic Reboot
+
+If you need Meadow to relaunch your app should it fail, the `Lifecycle` settings allow you to configure that behavior.
+
+First, set `ResetOnAppFailure` to true. Then, you can optionally configure a delay, in seconds, before restart using the `AppFailureRestartDelaySeconds` setting.
+
+For example, to configure Meadow to reboot your application, should it fail, after a 60-second delay, here is the configuration in YAML.
+
+```yml
+Lifecycle:
+    ResetOnAppFailure: true
+    AppFailureRestartDelaySeconds: 60
+```
+
+And here is the same configuration in JSON.
+
+<!-- TODO: This was an unconfirmed guess for the JSON structure. -->
+```json
+{
+    "Lifecycle": {
+        "ResetOnAppFailure": true,
+        "AppFailureRestartDelaySeconds": 60
+    }
+}
+```
+
+### Logging
+
+Logging configuration allows you to customize the level of data your Meadow application will log to its output channel.
+
+The log level default aligns with the .NET options: Trace, Debug, Information, Warning, and Error.
+
+<!-- TODO: Confirm Default is required, and what that means, exactly? -->
+
+```yml
+Logging:
+  LogLevel:
+    Default: "Trace"
+```
+
+```json
+{
+    "Logging": {
+        "LogLevel": {
+            "Default": "Trace"
+        }
+    }
+}
+```
+
+<!-- TODO: Confirm configuration structure and options -->
+
+### Custom Developer Application Settings
+
+<!-- TODO -->
 
 ## Sample Apps
 

--- a/docs/Meadow/Meadow.OS/Configuration/index.md
+++ b/docs/Meadow/Meadow.OS/Configuration/index.md
@@ -147,9 +147,9 @@ The contents of this file along with the `AutomaticallyStartNetwork` value in `m
 
 ## Application Configuration
 
-Either an `appconfig.yaml` or `appconfig.json` file can be used to set application configuration settings. The names are case sensitive. You can you one or the other, or both. If both application configuration files are used, the values in `appconfig.yaml` are applied first and then any values in `appconfig.json` are applied next.
+Either an `app.config.yaml` or `app.config.json` file can be used to set application configuration settings. The names are case sensitive. You can you one or the other, or both. If both application configuration files are used, the values in `app.config.yaml` are applied first and then any values in `app.config.json` are applied next.
 
-<!-- Confirm appconfig.* case sensitivity -->
+<!-- Confirm app.config.* case sensitivity -->
 <!-- Confirm behavior of dual config -->
 
 Custom developer-provided application settings can also be included.

--- a/docs/Meadow/Meadow.OS/Configuration/index.md
+++ b/docs/Meadow/Meadow.OS/Configuration/index.md
@@ -12,7 +12,7 @@ Meadow.OS support the following configuration sets:
 
 * **OS & Device Configuration** - Specified in the `meadow.config.yaml` file. Includes general board and system configuration settings.
 * **WiFi Network Credentials** - Specified in the `wifi.config.yaml`. Specifies WiFi access point and password configuration.
-* **Application Configuration** - Specified in `app.config.yaml` or `app.config.json`. Includes application settings for logging and reboot configuration. Also used for custom developer application settings.
+* **Application Configuration** - Specified in `app.settings.yaml` or `app.settings.json`. Includes application settings for logging and reboot configuration. <!-- Also used for custom developer application settings. -->
 
 These files are optional and the default values (shown below) will be used if the particular file is missing from the file system.
 
@@ -149,10 +149,7 @@ The contents of this file along with the `AutomaticallyStartNetwork` value in `m
 
 Either an `app.config.yaml` or `app.config.json` file can be used to set application configuration settings. The names are case sensitive. You can you one or the other, or both. If both application configuration files are used, the values in `app.config.yaml` are applied first and then any values in `app.config.json` are applied next.
 
-<!-- Confirm app.config.* case sensitivity -->
-<!-- Confirm behavior of dual config -->
-
-Custom developer-provided application settings can also be included.
+<!-- Custom developer-provided application settings can also be included. -->
 
 ### Lifecycle - Automatic Reboot
 
@@ -160,7 +157,7 @@ If you need Meadow to relaunch your app should it fail, the `Lifecycle` settings
 
 First, set `ResetOnAppFailure` to true. Then, you can optionally configure a delay, in seconds, before restart using the `AppFailureRestartDelaySeconds` setting.
 
-For example, to configure Meadow to reboot your application, should it fail, after a 60-second delay, here is the configuration in YAML.
+For example, to configure Meadow to wait 60 seconds after a failure before rebooting your application, here is the configuration in YAML.
 
 ```yml
 Lifecycle:
@@ -170,7 +167,6 @@ Lifecycle:
 
 And here is the same configuration in JSON.
 
-<!-- TODO: This was an unconfirmed guess for the JSON structure. -->
 ```json
 {
     "Lifecycle": {
@@ -185,8 +181,6 @@ And here is the same configuration in JSON.
 Logging configuration allows you to customize the level of data your Meadow application will log to its output channel.
 
 The log level default aligns with the .NET options: Trace, Debug, Information, Warning, and Error.
-
-<!-- TODO: Confirm Default is required, and what that means, exactly? -->
 
 ```yml
 Logging:
@@ -204,11 +198,7 @@ Logging:
 }
 ```
 
-<!-- TODO: Confirm configuration structure and options -->
-
-### Custom Developer Application Settings
-
-<!-- TODO -->
+<!-- TODO: ### Custom Developer Application Settings -->
 
 ## Sample Apps
 


### PR DESCRIPTION
- [x] Update top Application Configuration summary
- [x] Add Application Configuration section and intro
- [x] Add section on automatic reboot config
- [x] Add section on logging config
- [x] If we update to `app.config.yaml`, update anything currently showing `app.settings.yaml`
- [x] Add intro and section on custom developer application settings
- [x] Figure out what these settings do and how to properly change them (see WildernessLabs/Meadow.Core#179).