### PR TITLE
[DO NOT MERGE] Fix mismatched start/end element

### DIFF
--- a/docs/_layouts/ElectronicsTutorial.html
+++ b/docs/_layouts/ElectronicsTutorial.html
@@ -4,7 +4,7 @@ layout: SiteFrame
 
 <section class="banner small">
   <h1>{{ page.title }}</h1>
-  <p class="header-interior__subtitle">{% if page.subtitle %}<span>{{ page.subtitle }}</small>{% endif %}</p>
+  <p class="header-interior__subtitle">{% if page.subtitle %}<span>{{ page.subtitle }}</span>{% endif %}</p>
 </section>
 
 <button href="#" class="subcat-nav-trigger mobile-nav-trigger mobile" aria-expanded="false" data-la-initdispnone="true">Submenu</button>

--- a/docs/_layouts/Hardware.html
+++ b/docs/_layouts/Hardware.html
@@ -4,7 +4,7 @@ layout: SiteFrame
 
 <section class="banner small">
   <h1>{{ page.title }}</h1>
-  <p class="header-interior__subtitle">{% if page.subtitle %}<span>{{ page.subtitle }}</small>{% endif %}</p>
+  <p class="header-interior__subtitle">{% if page.subtitle %}<span>{{ page.subtitle }}</span>{% endif %}</p>
 </section>
 
 <button href="#" class="subcat-nav-trigger mobile-nav-trigger mobile" aria-expanded="false" data-la-initdispnone="true">Submenu</button>

--- a/docs/_layouts/Meadow.html
+++ b/docs/_layouts/Meadow.html
@@ -4,7 +4,7 @@ layout: SiteFrame
 
 <section class="banner small">
   <h1>{{ page.title }}</h1>
-  <p class="header-interior__subtitle">{% if page.subtitle %}<span>{{ page.subtitle }}</small>{% endif %}</p>
+  <p class="header-interior__subtitle">{% if page.subtitle %}<span>{{ page.subtitle }}</span>{% endif %}</p>
 </section>
 
 <button href="#" class="subcat-nav-trigger mobile-nav-trigger mobile" aria-expanded="false" data-la-initdispnone="true">Submenu</button>

--- a/docs/_layouts/Netduino.html
+++ b/docs/_layouts/Netduino.html
@@ -4,7 +4,7 @@ layout: SiteFrame
 
 <section class="banner small">
   <h1>{{ page.title }}</h1>
-  <p class="header-interior__subtitle">{% if page.subtitle %}<span>{{ page.subtitle }}</small>{% endif %}</p>
+  <p class="header-interior__subtitle">{% if page.subtitle %}<span>{{ page.subtitle }}</span>{% endif %}</p>
 </section>
 
 <button href="#" class="subcat-nav-trigger mobile-nav-trigger mobile" aria-expanded="false" data-la-initdispnone="true">Submenu</button>

--- a/docs/_layouts/Page.html
+++ b/docs/_layouts/Page.html
@@ -5,7 +5,7 @@ layout: SiteFrame
 <section class="header-interior">
     <div class="container">
         <h1>{{ page.title }}</h1>
-        <p class="header-interior__subtitle">{% if page.subtitle %}<span>{{ page.subtitle }}</small>{% endif %}</p>
+        <p class="header-interior__subtitle">{% if page.subtitle %}<span>{{ page.subtitle }}</span>{% endif %}</p>
     </div><!-- .container -->
 </section>
 

--- a/docs/_layouts/Samples.html
+++ b/docs/_layouts/Samples.html
@@ -4,7 +4,7 @@ layout: SiteFrame
 
 <section class="banner small">
   <h1>{{ page.title }}</h1>
-  <p class="header-interior__subtitle">{% if page.subtitle %}<span>{{ page.subtitle }}</small>{% endif %}</p>
+  <p class="header-interior__subtitle">{% if page.subtitle %}<span>{{ page.subtitle }}</span>{% endif %}</p>
 </section>
 
 <button href="#" class="subcat-nav-trigger mobile-nav-trigger mobile" aria-expanded="false" data-la-initdispnone="true">Submenu</button>


### PR DESCRIPTION
[DO NOT MERGE: I need to test this some more locally to make sure nothing looks too unusual. It's possible that some styling or structure may be based around the side-effects of this HTML hiccup.]

This fixes code that generates `<span></small>` mismatch in HTML generation.

Example: http://beta-developer.wildernesslabs.co/Meadow/Meadow_Basics/Apps/

In source, renders this section:

```html
<h1>Meadow Applications</h1>
<p class="header-interior__subtitle"><span>Meadow Basics</small></p>
```