### PR TITLE
Troubleshooting additions

### DIFF
--- a/docs/Meadow/Getting_Started/Deploying_Meadow/index.md
+++ b/docs/Meadow/Getting_Started/Deploying_Meadow/index.md
@@ -123,6 +123,13 @@ To update Meadow CLI, if already installed, execute the following command in you
 dotnet tool update WildernessLabs.Meadow.CLI --global
 ```
 
+If you are working on an ARM-based Mac (M1, M1 Pro, M2 CPU), you will also need to explicitly add the x64 version of `libusb` and add some additional locations to your `PATH` variable that aren't added by default.
+
+```console
+arch -x86_64 brew install libusb
+export PATH=$HOME/Meadow.CLI/Meadow.CLI/bin/Debug/:/usr/local/share/dotnet/x64/:$PATH
+```
+
 ### Install dfu-util
 
 To install `dfu-util`, we'll be using **Homebrew**. If you don't have it yet, [install Homebrew](https://brew.sh/) first.

--- a/docs/Meadow/Getting_Started/Deploying_Meadow/index.md
+++ b/docs/Meadow/Getting_Started/Deploying_Meadow/index.md
@@ -123,11 +123,11 @@ To update Meadow CLI, if already installed, execute the following command in you
 dotnet tool update WildernessLabs.Meadow.CLI --global
 ```
 
-If you are working on an ARM-based Mac (M1, M1 Pro, M2 CPU), you will also need to explicitly add the x64 version of `libusb` and add some additional locations to your `PATH` variable that aren't added by default.
+If you are working on an ARM-based Mac (M1, M1 Pro, M2 CPU), you will also need to explicitly add the x64 version of `libusb` and add an additional location to your `PATH` variable that aren't added by default on those systems.
 
 ```console
 arch -x86_64 brew install libusb
-export PATH=$HOME/Meadow.CLI/Meadow.CLI/bin/Debug/:/usr/local/share/dotnet/x64/:$PATH
+export PATH=/usr/local/share/dotnet/x64/:$PATH
 ```
 
 ### Install dfu-util

--- a/docs/Meadow/Meadow_Basics/Troubleshooting/index.md
+++ b/docs/Meadow/Meadow_Basics/Troubleshooting/index.md
@@ -26,7 +26,7 @@ Scott Hanselman has written a good [blog post](https://www.hanselman.com/blog/Ho
 
 ## Error when flashing Meadow (Windows)
 
-If you're getting the `Could not find a connected Meadow with the serial number #########`, the board might not have the write window drivers. To solve this, follow these steps:
+If you're getting the `Could not find a connected Meadow with the serial number #########`, the board might not have the correct Window drivers. To solve this, follow these steps:
 
 1. Open Device Manager
 1. Under USB Devices right click Meadow F7 Micro
@@ -38,6 +38,20 @@ If you're getting the `Could not find a connected Meadow with the serial number 
 1. Wait until the line: "Having trouble putting Meadow in DFU Mode, please press RST button on Meadow and press enter to try again" appears.
 1. Open [Zadig](https://www.hanselman.com/blog/HowToFixDfuutilSTMWinUSBZadigBootloadersAndOtherFirmwareFlashingIssuesOnWindows.aspx) and replace the driver.
 1. Wait for the flash to finish.
+
+## Error while updating Meadow after successful DFU Meadow.OS install
+
+While updating the Meadow.OS, you may encounter an error after successfully flashing the OS when your Meadow is rebooted.
+
+```console
+Meadow.CLI.Core.Exceptions.DeviceNotFoundException: Could not find a connected Meadow with the serial number
+```
+
+This means that something during the reboot didn't work correctly. You can work around this by doing another Meadow OS flash but skipping the DFU portion that worked previously.
+
+```console
+meadow flash os -d
+```
 
 ## Deploying from a Virtual Machine
 

--- a/docs/Meadow/Meadow_Basics/Troubleshooting/macOS/index.md
+++ b/docs/Meadow/Meadow_Basics/Troubleshooting/macOS/index.md
@@ -6,7 +6,7 @@ subtitle: Troubleshooting guide for macOS-specific issues
 
 ## `libusb` not found on ARM Macs
 
-While updating the Meadow.OS on an ARM Mac (M1, M1 Pro, M2, etc.), you may encounter an error after it successfully flashes the OS and tries to continue after rebooting the Meadow board.
+While updating the Meadow.OS on an ARM Mac (M1, M1 Pro, M2, etc.), you may encounter an `libusb` error.
 
 > An exception occurred while switching device to DFU Mode. Exception: System.DllNotFoundException: libusb-1.0 library not found.
 

--- a/docs/Meadow/Meadow_Basics/Troubleshooting/macOS/index.md
+++ b/docs/Meadow/Meadow_Basics/Troubleshooting/macOS/index.md
@@ -1,0 +1,18 @@
+---
+layout: Meadow
+title: macOS
+subtitle: Troubleshooting guide for macOS-specific issues
+---
+
+## `libusb` not found on ARM Macs
+
+While updating the Meadow.OS on an ARM Mac (M1, M1 Pro, M2, etc.), you may encounter an error after it successfully flashes the OS and tries to continue after rebooting the Meadow board.
+
+> An exception occurred while switching device to DFU Mode. Exception: System.DllNotFoundException: libusb-1.0 library not found.
+
+Currently, Meadow.OS deployments require an x64 version of `libusb` that isn't installed by default on ARM Macs. As a workaround, run the following commands to install the x64 version of `libusb` and then add some additional required locations to your `PATH`.
+
+```console
+arch -x86_64 brew install libusb
+export PATH=$HOME/Meadow.CLI/Meadow.CLI/bin/Debug/:/usr/local/share/dotnet/x64/:$PATH
+```

--- a/docs/_includes/MeadowNavigation.html
+++ b/docs/_includes/MeadowNavigation.html
@@ -38,6 +38,7 @@
     <li><a href="/Meadow/Meadow_Basics/Troubleshooting/">Troubleshooting</a>
         <ul>
             <li><a href="/Meadow/Meadow_Basics/Troubleshooting/Linux">Linux</a></li>
+            <li><a href="/Meadow/Meadow_Basics/Troubleshooting/macOS">macOS</a></li>
             <li><a href="/Meadow/Meadow_Basics/Troubleshooting/VisualStudio">Visual Studio</a></li>
         </ul>
     </li>


### PR DESCRIPTION
- [x] Steps for working around missing `libusb` on ARM macOS.
- [x] Steps for deploying just assemblies after successful Meadow.OS DFU deployment