### PR TITLE
Update F7 Micro and Core-Compute usage

### DIFF
--- a/docs/HackKit/Contents/index.md
+++ b/docs/HackKit/Contents/index.md
@@ -4,7 +4,7 @@ title: Hack Kit Pro Contents
 subtitle: Here we list all the components included in the Hack Kit Pro
 ---
 
-### F7 Micro Dev Kit
+### F7 Feather Dev Kit
 
 | Item                   | QTY | Description | |
 |------------------------|:---:|-------------|-|
@@ -36,7 +36,6 @@ subtitle: Here we list all the components included in the Hack Kit Pro
 | USB Breakout | 1 | Used to expose the `5V` and `GND` pins of a USB adapter so that it can be used as an external power supply to drive motors, and such. | ![Photo of a USB breakout board, converting from a USB A male plug to the four USB pins.](Images/usbBreakout.jpg) |
 | SPDT Switch | 2 | Small two-position switch. | ![Photo of two three-pin, two-position switches.](Images/switches.jpg) |
 
-
 ### ICs
 
 | Item                   | QTY | Description | |
@@ -44,7 +43,6 @@ subtitle: Here we list all the components included in the Hack Kit Pro
 | [74595 Shift Register](/docs/api/Meadow.Foundation/Meadow.Foundation.ICs.IOExpanders.x74595.html) | 2 | 8-port digital output expander chip. Adds 8 additional `DigitalOutputPort`s to a Meadow. Can be chained up to 8 for 64 total additional outputs. | ![Photo of two 74595 shift registers.](Images/74HC595.jpg) |
 | [MCP23008 IO Expander](/docs/api/Meadow.Foundation/Meadow.Foundation.ICs.IOExpanders.Mcp23x08.html) | 2 | 8-port digital IO expander chip that connects via SPI. Adds 8 additional digital ports that can be used as output or input with changed notification support. | ![Photo of two MCP23008 IO expanders.](Images/MCP23008.jpg) |
 | [H-Bridge Motor Controller](/docs/api/Meadow.Foundation/Meadow.Foundation.Motors.HBridgeMotor.html) | 1 | SN754410. Provides digital control for two motors using an external power source, controlled via PWM. | ![Photo of an SN7544IO H-Bridge motor controller.](Images/HBridgeMotor.jpg) |
-
 
 ### LEDs
 

--- a/docs/Meadow/Getting_Started/Hello_World/index.md
+++ b/docs/Meadow/Getting_Started/Hello_World/index.md
@@ -9,7 +9,7 @@ Once [Meadow.OS has been deployed to your board](/Meadow/Getting_Started/Deployi
 The video below shows you how to create and deploy your first Meadow app on a Mac:
 <p><iframe width="640" height="360" src="https://www.youtube.com/embed/wkekz5I7ycE" frameborder="3" allowfullscreen></iframe></p>
 
-Alternatively, you can follow this step by step guide for both macOS and Windows: 
+Alternatively, you can follow this step by step guide for both macOS and Windows:
 
 ## Step 1: Install Visual Studio Meadow Extensions
 
@@ -63,7 +63,7 @@ You'll also need to install the Meadow IDE Extension for Visual Studio for Mac.
 
  1. Open Visual Studio.
  2. Create a new Project: **File** -> **New Solution..**.
- 3. In the **Meadow** section, select *Meadow Application* and press **Next**.
+ 3. In the **Meadow** section, select _Meadow Application_ and press **Next**.
  4. Name your project `HelloMeadow` and choose project location.
  5. Press **Create**.
 
@@ -80,7 +80,7 @@ The Meadow application template is a simple application that will pulse the onbo
 ### Windows
 
  1. Connect your Meadow device to your development machine
- 2. Right-click anywhere in the toolbar area and you'll see *Meadow Device List* in the dropdown. Click on it and it will be added to your toolbar.
+ 2. Right-click anywhere in the toolbar area and you'll see _Meadow Device List_ in the dropdown. Click on it and it will be added to your toolbar.
  3. Select the Meadow device COM port that correspond to your board in the Meadow Device List toolbar dropdown
  4. Right-click project in Solution Explorer and choose **Deploy**.
  5. Wait 30-60 seconds for your application to start
@@ -176,7 +176,7 @@ using Meadow.Peripherals.Leds;
 These are the typical minimum set of namespaces in a Meadow app class and provide the following functionality:
 
 * `Meadow` - The root namespace contains Meadow application and OS classes, enabling you to interact with the Meadow.OS.
-* `Meadow.Devices` - Contains device-specific definitions for different Meadow boards, such as the F7 Micro Dev board, or the F7 Micro embeddable board.
+* `Meadow.Devices` - Contains device-specific definitions for different Meadow boards, such as the F7 Feather V1 and V2 dev boards, or the F7v2 Core-Compute module.
 * `Meadow.Foundation` - [Meadow.Foundation](/Meadow/Meadow.Foundation) is a set of open-source peripheral drivers and hardware control libraries that make hardware development with Meadow, plug-and-play.
 * `Meadow.Foundation.Leds` - Provided with the Meadow.Foundation library. Used to simplify use of RGB LEDs in this sample.
 * `Meadow.Peripherals.Leds` - Provided with the Meadow.Contracts library. Used to access LED type enumeration.
@@ -236,7 +236,6 @@ The `Initialize` call writes to the console for informational purposes, useful w
 #### Digital Output
 
 To pulse the color of the light emitted via the onboard LED, we can utilize the built in `StartPulse()` method of the `RgbPwmLed` class, this is done in the ShowColorPulse method, which takes a color and duration. All of this is tied together with the CycleColors call which will simply cycle through a variety of colors:
-
 
 ```csharp
 void CycleColors(TimeSpan duration)

--- a/docs/Meadow/Meadow.OS/Networking/Antenna/index.md
+++ b/docs/Meadow/Meadow.OS/Networking/Antenna/index.md
@@ -4,7 +4,7 @@ title: WiFi/Bluetooth Antenna
 subtitle: Understanding and switching between the onboard and external antenna options.
 ---
 
-Both the Meadow F7 Feather development board and Core Compute Module have an onboard ceramic chip antenna and a U.FL connector for an external antenna for the 2.4GHz WiFi and Bluetooth radio. Additionally, there is a software antenna switch for toggling between the two antenna; by default, the chip antenna is selected, and you must use the Meadow.OS device API to switch to the external antenna.
+Both the Meadow F7 Feather development board and Core-Compute Module have an onboard ceramic chip antenna and a U.FL connector for an external antenna for the 2.4GHz WiFi and Bluetooth radio. Additionally, there is a software antenna switch for toggling between the two antenna; by default, the chip antenna is selected, and you must use the Meadow.OS device API to switch to the external antenna.
 
 ## Determining the Currently Selected Antenna
 

--- a/docs/Meadow/Meadow.OS/Networking/index.md
+++ b/docs/Meadow/Meadow.OS/Networking/index.md
@@ -4,7 +4,7 @@ title: Networking
 subtitle: Network options and operation.
 ---
 
-Both the Meadow F7 Feather development board and Core Compute Module have Wi-Fi networking via the ESP32 co-processor. The Meadow Core Compute Module also adds optional ethernet capabilities.
+Both the Meadow F7 Feather development board and Core-Compute Module have Wi-Fi networking via the ESP32 co-processor. The Meadow Core-Compute Module also adds optional ethernet capabilities.
 
 ## Current Beta Limitations
 
@@ -14,9 +14,9 @@ Both the Meadow F7 Feather development board and Core Compute Module have Wi-Fi 
 
 For example code, see the following networking sample apps in the [Meadow.Core.Samples repo](https://github.com/wildernesslabs/Meadow.Core.Samples):
 
-* **[Wifi_Basics](https://github.com/WildernessLabs/Meadow.Core.Samples/tree/main/Source/Meadow.Core.Samples/Network/WiFi_Basics)** - Covers the basics of enumerating and connecting to WiFi networks.
+* **[WiFi_Basics](https://github.com/WildernessLabs/Meadow.Core.Samples/tree/main/Source/Meadow.Core.Samples/Network/WiFi_Basics)** - Covers the basics of enumerating and connecting to WiFi networks.
 * **[HttpListener](https://github.com/WildernessLabs/Meadow.Core.Samples/tree/main/Source/Meadow.Core.Samples/Network/HttpListener)** - Shows how to respond to HTTP requests with `HttpListenerContext`, `HttpListenerRequest`, and `HttpListenerResponse`.
-* **[Antenna Switching](https://github.com/WildernessLabs/Meadow.Core.Samples/tree/main/Source/Meadow.Core.Samples/Network/Antenna_Switching)** - Shows how to use the antenna API to switch between the onboard and external antenna connection.
+* **[Antenna_Switching](https://github.com/WildernessLabs/Meadow.Core.Samples/tree/main/Source/Meadow.Core.Samples/Network/Antenna_Switching)** - Shows how to use the antenna API to switch between the onboard and external antenna connection.
 
 # WiFi
 

--- a/docs/Meadow/Meadow.OS/Networking/index.md
+++ b/docs/Meadow/Meadow.OS/Networking/index.md
@@ -4,7 +4,7 @@ title: Networking
 subtitle: Network options and operation.
 ---
 
-Both the Meadow F7 Micro development board and Core Compute Module have Wi-Fi networking via the ESP32 co-processor. The Meadow Core Compute Module also adds optional ethernet capabilities.
+Both the Meadow F7 Feather development board and Core Compute Module have Wi-Fi networking via the ESP32 co-processor. The Meadow Core Compute Module also adds optional ethernet capabilities.
 
 ## Current Beta Limitations
 

--- a/docs/Meadow/Meadow_Basics/Hardware/F7v2/index.md
+++ b/docs/Meadow/Meadow_Basics/Hardware/F7v2/index.md
@@ -4,10 +4,10 @@ title: Meadow F7v2
 subtitle: Version 2 of the Meadow F7 Board Series.
 ---
 
-The Meadow F7v2 System-on-Module (SoM) is available in two models, based on two differing form factors: 
+The Meadow F7v2 System-on-Module (SoM) is available in two models, based on two differing form factors:
 
- * **Meadow F7v2 Micro Development Module** - An Adafruit Feather specification compatible design, intended for development, prototyping, and low-volume (1,000 or less) production.
- * **Meadow F7v2 Core-Compute Module** -  A surface mount device (SMD) intended for high-volume and industrial production, the F7 Production also adds Ethernet and SD card capabilities.
+* **Meadow F7v2 Feather Development Module** - An Adafruit Feather specification compatible design, intended for development, prototyping, and low-volume (1,000 or less) production.
+* **Meadow F7v2 Core-Compute Module** -  A surface mount device (SMD) intended for high-volume and industrial production, the F7 Production also adds Ethernet and SD card capabilities.
 
 ![Rendering of the two F7v2 boards: left is the Meadow F7v2 Development Module with labeled pins for prototyping and development, right is the Core-Compute Module in a minimal rectangular footprint intended for surface mount use.](/Common_Files/Meadow_F7v2_Modules.png)
 
@@ -15,15 +15,15 @@ The Meadow F7v2 System-on-Module (SoM) is available in two models, based on two 
 
 The F7v2 includes a number of upgrades from the previous v1 board, including:
 
- * **64MB of Flash** - This is an upgrade from 32MB in v1, and with only 4MB or reserved system space, a whopping 60MB is now user accessible.
- * **Upgraded Antenna** - We changed out the antenna with a new model that has 10x better performance. In fact, we get better WiFi performance out of the board than our iPhones!
- * **Fully SMT-Compatible** - The F7v2 has hybrid castellated header/IO mounts that allow for use as both a through-hole (PTH) device, as well as a surface mount device (SMD/SMT). Additionally, there are no components on the underside, so it will solder flush without impediment.
- * **I2S Sound** - Coming soon via Meadow.Core APIs, we’ve added a full set of hardware IO for inter-integrated sound, which enables both I2S microphone input, and sound output.
- * **Low-power Timer Input** - Also available soon in software, F7v2 includes a pin that has a low-power timer that can count pulses even while the board is asleep!
- * **Fixed Battery Voltage** - A bug in the design of v1.0 meant that the `3V3` rail could dip as low as `3.0V` when being powered by a battery via the integrated battery connector/charging cicrcuit. We changed the power components to make sure that the full `3.3V` is available.
- * **Better Buttons** - We also swapped out the buttons on the board with high-quality Wurth Elektrik buttons that have a greater surface area and a much nicer click.
- * **Upgraded Silkscreen Design** - The new silk screen makes bus IO identification much easier.
- * **Open Source** - We'll be open-sourcing the design soon. This will allow folks to use it with other platform technologies, or build their own board.
+* **64MB of Flash** - This is an upgrade from 32MB in v1, and with only 4MB or reserved system space, a whopping 60MB is now user accessible.
+* **Upgraded Antenna** - We changed out the antenna with a new model that has 10x better performance. In fact, we get better WiFi performance out of the board than our iPhones!
+* **Fully SMT-Compatible** - The F7v2 has hybrid castellated header/IO mounts that allow for use as both a through-hole (PTH) device, as well as a surface mount device (SMD/SMT). Additionally, there are no components on the underside, so it will solder flush without impediment.
+* **I2S Sound** - Coming soon via Meadow.Core APIs, we’ve added a full set of hardware IO for inter-integrated sound, which enables both I2S microphone input, and sound output.
+* **Low-power Timer Input** - Also available soon in software, F7v2 includes a pin that has a low-power timer that can count pulses even while the board is asleep!
+* **Fixed Battery Voltage** - A bug in the design of v1.0 meant that the `3V3` rail could dip as low as `3.0V` when being powered by a battery via the integrated battery connector/charging circuit. We changed the power components to make sure that the full `3.3V` is available.
+* **Better Buttons** - We also swapped out the buttons on the board with high-quality Wurth Elektrik buttons that have a greater surface area and a much nicer click.
+* **Upgraded Silkscreen Design** - The new silk screen makes bus IO identification much easier.
+* **Open Source** - We'll be open-sourcing the design soon. This will allow folks to use it with other platform technologies, or build their own board.
 
 ### Additional Core-Compute Features
 
@@ -35,14 +35,14 @@ The core-compute module adds additional features not available in the developer 
 
 ## Developing with the F7v2
 
-Developing with the F7v2 board is largely the same as with the v1 series, but with two minor differences. 
+Developing with the F7v2 board is largely the same as with the v1 series, but with two minor differences.
 
 ### `App` Class Definition
 
-The Meadow.Core API includes strongly-typed APIs for the pinout of the board, but in order to get the right pin definition, you'll need to modify you `App` class definition from `F7Micro` to `F7MicroV2` as illustrated below:
+The Meadow.Core API includes strongly-typed APIs for the pinout of the board, but in order to get the right pin definition, you'll need to modify you `App` class definition from `F7Feather` to `F7FeatherV2` as illustrated below:
 
 ```csharp
-public class LEDApp : App<F7MicroV2, LEDApp>
+public class LEDApp : App<F7FeatherV2>
 ```
 
 Then in your application, you can get strongly-typed access to the pins on the board as before. From within the app class, it's available via the `Device` class:
@@ -58,7 +58,6 @@ var d5 = Device.CreateDigitalInputPort(MeadowApp.Device.Pins.D05);
 ```
 
 Note that `MeadowApp` should be the name of your application class.
-
 
 ### Pinout
 

--- a/docs/Meadow/Meadow_Basics/Hardware/index.md
+++ b/docs/Meadow/Meadow_Basics/Hardware/index.md
@@ -4,7 +4,7 @@ title: Meadow Hardware
 subtitle: Meadow System-on-Modules (SoM) boards for prototype and production.
 ---
 
-The Meadow F7 is a workhorse Wi-Fi and Bluetooth enabled System-on-Module (SoM) microcontroller-based board designed for sophisticated IoT applications and is based on the STMicroelectronics STM32F7 microcontroller (MCU) with an Espressif ESP-32 coprocessor.
+The Meadow F7 is a workhorse Wi-Fi and Bluetooth enabled System-on-Module (SoM) microcontroller-based board designed for sophisticated IoT applications and is based on the STMicroelectronics STM32F7 microcontroller (MCU) with an Espressif ESP32 coprocessor.
 
 ![Photo of the Meadow F7 board.](/Common_Files/F7v2_Dev_Medium_Cropped.jpg)
 
@@ -12,48 +12,48 @@ The Meadow F7 is provisioned with Meadow.OS which runs full .NET Standard v2.1 a
 
 ## Form-Factors
 
-The Meadow F7v2 System-on-Module (SoM) is available in two models, based on two differing form factors: 
+The Meadow F7v2 System-on-Module (SoM) is available in two models, based on two differing form factors:
 
- * **Meadow F7v2 Micro Development Module** - An Adafruit Feather specification compatible design, intended for development, prototyping, and low-volume (1,000 or less) production.
- * **Meadow F7v2 Core-Compute Module** -  A surface mount device (SMD) intended for high-volume and industrial production, the F7 Production also adds Ethernet and SD card capabilities.
+* **Meadow F7v2 Feather Development Module** - An Adafruit Feather specification compatible design, intended for development, prototyping, and low-volume (1,000 or less) production.
+* **Meadow F7v2 Core-Compute Module** -  A surface mount device (SMD) intended for high-volume and industrial production, the F7 Production also adds Ethernet and SD card capabilities.
 
 ![Rendering of the two F7v2 boards: left is the Meadow F7v2 Development Module with labeled pins for prototyping and development, right is the Core-Compute Module in a minimal rectangular footprint intended for surface mount use.](/Common_Files/Meadow_F7v2_Modules.png)
 
 ## F7v2 Features
 
- * Fully Surface Mount Technology (SMT) compatible. Both modules can be used in SMD designs without the need for through-hole (PTH)  soldering.
- * STMicroelectronics STM32F7 32-bit ARM Cortex-M7 based core MCU at up to 216MHz
-   * 2MB internal Flash memory
-   * 412Kb internal RAM
-   * 2D Graphics Acceleration (DMA2D) via ST Chrom-ART Accelerator
-   * Internal, low-power realtime clock (RTC)
-   * Cryptographic Hardware Acceleration for AES 128, 192, 256, triple DES, HASH (MD5, SHA-1, SHA-2), and HMAC
-    True random number generator
-    Floating point unit (FPU)
-    Secure Boot secure, encrypted firmware loader
- * Espressif ESP32 (ESP-Pico-D4) Xtensa 32-bit dual-core LX6 up to 240MHz coprocessor.
-   * 2.4GHz WiFi 802.11 b/g/n with WFA, WPA/WPA2 and WAPI
-   * Bluetooth 4.2, 5.1
- * 32MB external, onboard QSPI RAM
- * 64MB external, onboard non-volatile Flash memory (60MB available for user code)
- * 25 Mixed Signal IO ports (6/8x Analog, 12x PWM, 3x UART, I2C, SPI, CAN, 2x DAC)
- * On-board 2.4GHz ceramic chip antenna
- * U.FL external antenna connector
- * RoHS compliant (lead and hazardous materials-free)
+* Fully Surface Mount Technology (SMT) compatible. Both modules can be used in SMD designs without the need for through-hole (PTH)  soldering.
+* STMicroelectronics STM32F7 32-bit ARM Cortex-M7 based core MCU at up to 216MHz
+  * 2MB internal Flash memory
+  * 412Kb internal RAM
+  * 2D Graphics Acceleration (DMA2D) via ST Chrom-ART Accelerator
+  * Internal, low-power realtime clock (RTC)
+  * Cryptographic Hardware Acceleration for AES 128, 192, 256, triple DES, HASH (MD5, SHA-1, SHA-2), and HMAC
+    * True random number generator
+    * Floating point unit (FPU)
+    * Secure Boot secure, encrypted firmware loader
+* Espressif ESP32 (ESP-Pico-D4) Xtensa 32-bit dual-core LX6 up to 240MHz coprocessor.
+  * 2.4GHz WiFi 802.11 b/g/n with WFA, WPA/WPA2 and WAPI
+  * Bluetooth 4.2, 5.1
+* 32MB external, onboard QSPI RAM
+* 64MB external, onboard non-volatile Flash memory (60MB available for user code)
+* 25 Mixed Signal IO ports (6/8x Analog, 12x PWM, 3x UART, I2C, SPI, CAN, 2x DAC)
+* On-board 2.4GHz ceramic chip antenna
+* U.FL external antenna connector
+* RoHS compliant (lead and hazardous materials-free)
 
-## Meadow F7v2 Micro Features
+## Meadow F7v2 Feather Features
 
-The Meadow F7 Micro model has additional onboard features designed to make developing and prototyping easier.
+The Meadow F7 Feather models have additional onboard features designed to make developing and prototyping easier.
 
 ![Rendering of the top and bottom of the Meadow F7 Development Module showing all components on the top for surface mounting and the Meadow and Wilderness Labs logos screened on the bottom.](/Common_Files/Meadow_F7v2_Illustration.png)
 
- * Reset and Boot buttons
- * Onboard user-accessible RGB LED
- * Micro USB 3.0 with USB On-the-Go (OTG)
- * Integrated 3.7V LiPo/LiIon battery charging and JST-PH 2-pin battery connector
- * Can be powered via standard USB, or 5V/3V3 rails
- * Integrated switching power supply capable of providing 800mA when powered from USB or 5V rail
- * SMT and PTH compatible
+* Reset and Boot buttons
+* Onboard user-accessible RGB LED
+* Micro USB 3.0 with USB On-the-Go (OTG)
+* Integrated 3.7V LiPo/LiIon battery charging and JST-PH 2-pin battery connector
+* Can be powered via standard USB, or 5V/3V3 rails
+* Integrated switching power supply capable of providing 800mA when powered from USB or 5V rail
+* SMT and PTH compatible
 
 ## Meadow F7v2 Core-Compute Features
 
@@ -61,6 +61,6 @@ The Meadow F7 Core-Compute model is designed to be an easy upgrade path to produ
 
 ![Rendering of the Meadow F7 Core-Compute module in a minimal rectangular footprint intended for surface mount use.](/Common_Files/Meadow_F7v2_Core-Compute_Illustration.png)
 
- * Ultra-small Surface Mount Device (SMD) form factor.
- * External SD Card interface
- * Dual-Port External Ethernet interface
+* Ultra-small Surface Mount Device (SMD) form factor.
+* External SD Card interface
+* Dual-Port External Ethernet interface

--- a/docs/Meadow/Meadow_Basics/IO/Analog/index.md
+++ b/docs/Meadow/Meadow_Basics/IO/Analog/index.md
@@ -6,9 +6,9 @@ subtitle: Reading and writing non-binary voltages via the Analog-to-Digital Conv
 
 In modern digital electronics, we often deal with finite states of `HIGH` or `LOW`, which represent digital `1`/`0`, or `On`/`Off`, respectively. However, there are many sensors or other integrations that communicate not in binary, but in a range of voltages. For instance, a [TMP35 analog temp sensor](/docs/api/Meadow.Foundation/Meadow.Foundation.Sensors.Temperature.AnalogTemperature.html) might output `0V` when it's reading an ambient temperature of `0ºC`, `1.6V` @ `50ºC`, and `3.3V` @ `100ºC`.
 
-Analog ports are specifically design for this scenario, and are able to operate throughout a specified range of voltages, in both an input (reading) and output (writing) capacity. 
+Analog ports are specifically design for this scenario, and are able to operate throughout a specified range of voltages, in both an input (reading) and output (writing) capacity.
 
-On the Meadow F7 Micro, Analog signals are written or read with a 12-bit resolution, which means that the total range of voltage values are divided by `4,096` steps.
+On the Meadow F7 Feather, analog signals are written or read with a 12-bit resolution, which means that the total range of voltage values are divided by `4,096` steps.
 
 Meadow has the capabilities to both read and write analog signals, but presently only the input/read functionality is exposed via API.
 
@@ -24,7 +24,7 @@ Analog input is converted to a digital value via the onboard _Analog to Digital 
 IAnalogInputPort analogIn = Device.CreateAnalogInputPort(Device.Pins.A02);
 ```
 
-### Getting the voltage value via the `Read()` method.
+### Getting the voltage value via the `Read()` method
 
 Once the analog input port has been created, the voltage input can be read on a one-off fashion via the `Read()` method:
 
@@ -34,7 +34,7 @@ Voltage voltage = await analogIn.Read();
 
 ### Events and IObservable API
 
-As with other input APIs, the Analog input APIs support both classic .NET events and the `IObservable` pattern, for advanced notification filtering. 
+As with other input APIs, the Analog input APIs support both classic .NET events and the `IObservable` pattern, for advanced notification filtering.
 
 #### Classic .NET Events
 
@@ -49,7 +49,7 @@ analogIn.StartUpdating();
 
 #### Filterable Observers
 
-For more advanced filtering, or to use reactive-style programming, an `Observer` can be created and subscribe to notifcations, with an optional filter. For example, the following code creates a filterable observer than is only notified when when the voltage changes by at least `0.1V`:
+For more advanced filtering, or to use reactive-style programming, an `Observer` can be created and subscribe to notifications, with an optional filter. For example, the following code creates a filterable observer than is only notified when when the voltage changes by at least `0.1V`:
 
 ```csharp
 var observer = IAnalogInputPort.CreateObserver(
@@ -80,19 +80,18 @@ In order to get events or notifications, the `StartUpdating()` method must be ca
 void StartUpdating(int sampleCount = 10, int sampleIntervalDuration = 40, int standbyDuration = 100);
 ```
 
-For more information on oversampleing, see the [Working with Sensor guide](/Meadow/Meadow.Foundation/Working_with_Sensors/).
-
+For more information on oversampling, see the [Working with Sensor guide](/Meadow/Meadow.Foundation/Working_with_Sensors/).
 
 ### Input Voltage Tolerance and Sample Circuit
 
 When using the analog input ports, your circuit should take into account two considerations:
 
- * **Input Voltage Tolerance** - The maximum voltage that the ADC can handle is `3.3V`.
- * **Value Normalization** - A small capacitor can be used to help normalize the input voltage.
+* **Input Voltage Tolerance** - The maximum voltage that the ADC can handle is `3.3V`.
+* **Value Normalization** - A small capacitor can be used to help normalize the input voltage.
 
 #### Input Voltage Tolerance
 
-It's important to note that unlike the digital inputs (which are `5V` tolerant), the analog inputs on the F7 Micro are only `3.3V` tolerant, meaning any input signals above `3.3V` may damage the chip. If you expect input signals to exceed `3.3V`, there are two ways to protect the input.
+It's important to note that unlike the digital inputs (which are `5V` tolerant), the analog inputs on the F7 Feather are only `3.3V` tolerant, meaning any input signals above `3.3V` may damage the chip. If you expect input signals to exceed `3.3V`, there are two ways to protect the input.
 
 ##### Dividing Input Voltage
 
@@ -114,9 +113,9 @@ For example, the following circuit illustrates these concepts in action. It uses
 
 Examining it, it has several important features:
 
- * **Voltage Divider** - The output of the solar panel comes in on the `6V_Solar` net and the first thing that happens is that it hits a voltage divider (`R16` and `R17`) that divides the input voltage in half by sinking half of it to `GND`. Typically, solar panels output a maximum of `6.5V`, so by dividing that in half, at full power the ADC will only receive `3.25V` at maximum. 
- * **Transient Voltage Suppression** - `D1` in the diagram is a diode that connects the divided voltage output to the `3V3` rail. As long as the voltage to that diode is less than the voltage on the `3V3` rail, it will go into the ADC as, expected. However, if a voltage spike occurs and that voltage exceeds the `3V3` raile, for instance, if there's a static eletricity discharge from the solar panel, it will dump any excess voltage onto that rail.
- * **Smoothing Capacitor** - `C2` in the diagram is a `0.1µf` capacitor that will store the input voltage and resist fast changes to the voltage level, providing a smoother value.
+* **Voltage Divider** - The output of the solar panel comes in on the `6V_Solar` net and the first thing that happens is that it hits a voltage divider (`R16` and `R17`) that divides the input voltage in half by sinking half of it to `GND`. Typically, solar panels output a maximum of `6.5V`, so by dividing that in half, at full power the ADC will only receive `3.25V` at maximum.
+* **Transient Voltage Suppression** - `D1` in the diagram is a diode that connects the divided voltage output to the `3V3` rail. As long as the voltage to that diode is less than the voltage on the `3V3` rail, it will go into the ADC as, expected. However, if a voltage spike occurs and that voltage exceeds the `3V3` raile, for instance, if there's a static eletricity discharge from the solar panel, it will dump any excess voltage onto that rail.
+* **Smoothing Capacitor** - `C2` in the diagram is a `0.1µf` capacitor that will store the input voltage and resist fast changes to the voltage level, providing a smoother value.
 
 Additionally, there is one more intersting component in the circuit, `D2`, which is a diode that will make sure when the Meadow board is plugged into USB, the `5V` rail power isn't fed into the solar intensity gauge circuit.
 

--- a/docs/Meadow/Meadow_Basics/IO/Digital/PWM/index.md
+++ b/docs/Meadow/Meadow_Basics/IO/Digital/PWM/index.md
@@ -54,11 +54,11 @@ PWM signals can be generated via hardware (on the microcontroller) as well as vi
 
 Nearly every digital pin on the Meadow F7 board supports PWM.
 
-#### Meadow F7v2 Micro Pinout
+#### Meadow F7v2 Feather Pinout
 
 ![Meadow F7v2 pinout diagram showing pins used for multiple functions](/Common_Files/Meadow_F7v2_Micro_Pinout.svg){:standalone}
 
-#### Meadow F7v1 Micro Pinout
+#### Meadow F7v1 Feather Pinout
 
 ![Meadow F7v1 pinout diagram showing pins used for multiple functions](/Common_Files/Meadow_F7_Micro_Pinout.svg){:standalone}
 

--- a/docs/Meadow/Meadow_Basics/IO/Digital/Protocols/I2C/index.md
+++ b/docs/Meadow/Meadow_Basics/IO/Digital/Protocols/I2C/index.md
@@ -6,7 +6,7 @@ subtitle: Introduction to the Inter-Integrated Circuit (IIC/I2C) protocol.
 
 [I2C (Inter-Integrated Circuit)](https://en.wikipedia.org/wiki/I%C2%B2C), pronounced, "eye-squared-sea", is a communication protocol allowing bi-directional communication between devices using only two signal wires (in addition to power and ground):
 
-![Illustration of a Meadow F7 Micro board with two peripherals (addresses 0x40 and 0x72) connected to I2C via pin D07 as the data line and D08 as the clock line along with 3.3V pull-up resistors on both lines](I2C_Circuit.svg){:standalone}
+![Illustration of a Meadow F7 Feather board with two peripherals (addresses 0x40 and 0x72) connected to I2C via pin D07 as the data line and D08 as the clock line along with 3.3V pull-up resistors on both lines](I2C_Circuit.svg){:standalone}
 
 ## Hardware
 
@@ -20,11 +20,11 @@ The clock signal determines the rate at which data can be transferred, however, 
 
 Additionally, adding more devices to the bus can also limit the maximum speed.
 
-The I2C `CLK` pin can be found on the Meadow F7 Micro labeled `D08`.
+The I2C `CLK` pin can be found on the Meadow F7 Feather labeled `D08`.
 
 ### Data Signal (`DAT`)
 
-The data signal wire carries the actual messages and can be found on the F7 Micro pin labeled `D07`.
+The data signal wire carries the actual messages and can be found on the F7 Feather pin labeled `D07`.
 
 ## Master + Client Messaging
 
@@ -81,4 +81,3 @@ These methods are also available via the I2C bus, but require the address of the
 ```csharp
 i2cBus.WriteByte(i2cPeripheral.Address, 0x01);
 ```
-

--- a/docs/Meadow/Meadow_Basics/IO/Digital/Protocols/SPI/index.md
+++ b/docs/Meadow/Meadow_Basics/IO/Digital/Protocols/SPI/index.md
@@ -38,9 +38,9 @@ Note: SPI supports shared `CS` lines in a _daisy-chain_ configuration, but it's 
 
 ## Meadow SPI Pins
 
-The SPI pins on the F7 Micro are labeled `SCK`, `MOSI` (`COPI`), and `MISO` (`CIPO`) and can be found between `A05` and `D00`:
+The SPI pins on the F7 Feather are labeled `SCK`, `MOSI` (`COPI`), and `MISO` (`CIPO`) and can be found between `A05` and `D00`:
 
-![Illustration of a Meadow F7 Micro board with two peripherals (Chip Select 1 and Chip Select 2) connected via SPI using the SCK, MOSI, and MISO pins as well as D00 and D01 pins for chip select](/Common_Files/Meadow_F7_Micro_Pinout.svg){:standalone}
+![Illustration of a Meadow F7 Feather board with two peripherals (Chip Select 1 and Chip Select 2) connected via SPI using the SCK, MOSI, and MISO pins as well as D00 and D01 pins for chip select](/Common_Files/Meadow_F7_Micro_Pinout.svg){:standalone}
 
 Any pin that supports digital output can be used as a chip select line.
 
@@ -76,5 +76,3 @@ These methods are also available via the SPI bus, but require the chip select po
 ```csharp
 spiBus.WriteByte(spiPeriph.ChipSelect, 0x01);
 ```
-
-

--- a/docs/Meadow/Meadow_Basics/IO/Digital/Protocols/UART/index.md
+++ b/docs/Meadow/Meadow_Basics/IO/Digital/Protocols/UART/index.md
@@ -6,13 +6,13 @@ subtitle: Serial communications over UART/RS-232.
 
 Standard serial, typically referred to as RS-232 or UART (Universal Asynchronous Receiver Transmitter) is a moderate-speed, reliable, old-school, digital protocol used to communicate with a single device, using two wires:
 
-![](Serial(UART)_Circuit.svg){:standalone}
+![Illustration showing a Meadow board connected to for UART serial on COM4, with a receive line on pin D00 and a transmit line on pin D01.](Serial(UART)_Circuit.svg){:standalone}
 
-Depending on the hardware involved, serial can be used in extremely noisy industrial environments, over long distances; up to 60 meters (200 feet). 
+Depending on the hardware involved, serial can be used in extremely noisy industrial environments, over long distances; up to 60 meters (200 feet).
 
 ## Hardware
 
-Standard serial uses two lines for communication; a transmit (`TX`) line for sending messages to the peripheral, and a receive (`RX`) for listening to messages sent from the peripheral. 
+Standard serial uses two lines for communication; a transmit (`TX`) line for sending messages to the peripheral, and a receive (`RX`) for listening to messages sent from the peripheral.
 
 ### Meadow TX => Peripheral RX, Meadow RX => Peripheral TX
 
@@ -24,18 +24,17 @@ In addition to `TX` and `RX`, serial devices will also have ground and power pin
 
 If the device is powered by an external power supply, you must make sure the external power's ground is connected to the Meadow `GND` so that their voltages are the same.
 
-
 ### UART/TTL vs RS-232
 
-The RS-232 specification is a complete specification that includes hardware designs, electrical characteristics, and protocol specifications. 
+The RS-232 specification is a complete specification that includes hardware designs, electrical characteristics, and protocol specifications.
 
 However, within that specification are generally two different flavors that describe the electrical characteristics of the protocol; UART/TTL & RS-232.
 
 Serial has been around for a long time; before USB, it used to be a standard way for computers to talk to various peripherals such as keyboards and mice and connected to the serial port on a computer via an RS-232 cable with a connector like this:
 
-![](RS232_Cable.svg){:standalone}
+![Photo of the end of an RS232 cable showing the trapezoidal plug shape and nine pins, four on the narrower side and five on the wider side.](RS232_Cable.svg){:standalone}
 
-And many industrial peripherals that use standard serial communications still use RS-232 connectors. 
+And many industrial peripherals that use standard serial communications still use RS-232 connectors.
 
 #### Voltage Difference
 
@@ -51,25 +50,25 @@ Fortunately, many modern serial peripherals operate on TTL voltage levels. Howev
 
 When using an RS-232 peripheral, the signal voltages must be level-shifted and inverted (high voltage in RS-232 signifies `0`, whereas low-voltage at TTL signifies `0`) in order to communicate. Fortunately there are low cost ICs (Integrated Circuits) that do this, such as the MAX232 chip.
 
-Additionally, [Sparkfun has an RS-232 to TTL Shifter breakout board](https://www.sparkfun.com/products/449) that not only converts RS-232 to TTL levels, but also includes an onboard RS-232 connector:
+Additionally, [SparkFun has an RS-232 to TTL Shifter breakout board](https://www.sparkfun.com/products/449) that not only converts RS-232 to TTL levels, but also includes an onboard RS-232 connector:
 
 ![Photo of a SparkFun RS232 to TTL converter board with a 9-pin RS-232 port.](SparkFun_RS232_Shifter.svg){:standalone}
 
 ## Meadow Serial Ports
 
-The Meadow F7 Micro has two exposed serial ports, named `COM4` and `COM1` with the following pinout:
+The Meadow F7 Feather has two exposed serial ports, named `COM4` and `COM1` with the following pinout:
 
- * **COM4** - `D00` = `RX`, `D01` = `TX`
- * **COM1** - `D13` = `RX`, `D12` = `TX`
+* **COM4** - `D00` = `RX`, `D01` = `TX`
+* **COM1** - `D13` = `RX`, `D12` = `TX`
 
-![Illustration of a Meadow F7 Micro board with COM4 on pins D00 and D01, and COM1 on pins D12 and D13](/Common_Files/Meadow_F7_Micro_Pinout.svg){:standalone}
+![Illustration of a Meadow F7 Feather board with COM4 on pins D00 and D01, and COM1 on pins D12 and D13](/Common_Files/Meadow_F7_Micro_Pinout.svg){:standalone}
 
 # Using the Meadow Serial API
 
 Because serial is a legacy technology, working with it can be a little tricky. In fact, because of this, we have two serial port classes that you can use for serial communications:
 
- * **`ISerialMessagePort`** - This is a modern, asynchronous take on serial communications that is thread-safe and asynchronous in nature. This is the recommended way to use serial on Meadow for nearly all use cases.
- * **`ISerialPort`** - For legacy uses, this works like traditional serial ports, it's not thread-safe, and care must be taken to make sure that the communications buffer is used appropriately if there are multiple subscribers to its events.
+* **`ISerialMessagePort`** - This is a modern, asynchronous take on serial communications that is thread-safe and asynchronous in nature. This is the recommended way to use serial on Meadow for nearly all use cases.
+* **`ISerialPort`** - For legacy uses, this works like traditional serial ports, it's not thread-safe, and care must be taken to make sure that the communications buffer is used appropriately if there are multiple subscribers to its events.
 
 For both classes, creating, opening, and writing to the underlying serial port is effectively the same, but the `ISerialMessagePort` handles reads in an asynchronous fashion, and bundles them into _messages_ that can provide a much easier way of reading data coming in. In contrast, the class `ISerialPort` class must be manually read from when data comes in.
 
@@ -82,13 +81,11 @@ For both classes, creating, opening, and writing to the underlying serial port i
 
 The `ISerialMessagePort` is configured in its constructor to operate in either of those two modes.
 
-
 ### Suffix Delimited Messages
 
-Often times, serial peripherals send varying length messages that are terminated by a sequence. For instance, GPS recievers send NMEA sentences of 
-indeterminate length, but each sentence ends with the "newline" suffix of carriage-return and line-feed characters (`\r\n`) as in the following:
+Often times, serial peripherals send varying length messages that are terminated by a sequence. For instance, GPS receivers send NMEA sentences of indeterminate length, but each sentence ends with the "newline" suffix of carriage-return and line-feed characters (`\r\n`) as in the following:
 
-```
+```console
 $GPGSA,A,1,,,,,,,,,,,,,,,*1E
 $GPRMC,000049.799,V,,,,,0.00,0.00,060180,,,N*48
 $GPVTG,0.00,T,,M,0.00,N,0.00,K,N*32
@@ -105,8 +102,7 @@ ISerialMessagePort CreateSerialMessagePort(SerialPortName portName, byte[] suffi
     StopBits stopBits = StopBits.One, int readBufferSize = 4096);
 ```
 
-For instance, if we wanted to create a serial port on `COM4` (pins `D00` and `D01` on the F7 Micro) that defines `\r\n` as its suffix delimiter, we 
-can use the following code:
+For instance, if we wanted to create a serial port on `COM4` (pins `D00` and `D01` on the F7 Feather) that defines `\r\n` as its suffix delimiter, we can use the following code:
 
 ```csharp
 Device.CreateSerialMessagePort(Device.SerialPortNames.Com4, 
@@ -117,7 +113,7 @@ Device.CreateSerialMessagePort(Device.SerialPortNames.Com4,
 
 Sometimes, serial peripherals will send fixed-length messages that have a common prefix as in the following:
 
-```
+```console
 $0480880
 $0420029
 $2083992
@@ -134,8 +130,7 @@ ISerialMessagePort CreateSerialMessagePort(SerialPortName portName, byte[] prefi
 
 ```
 
-For instance, if we wanted to create a serial port on `COM4` (pins `D00` and `D01` on the F7 Micro) that defines `$` as its prefix delimiter, and has
-a 6 byte message length, we can use the following code:
+For instance, if we wanted to create a serial port on `COM4` (pins `D00` and `D01` on the F7 Feather) that defines `$` as its prefix delimiter, and has a 6 byte message length, we can use the following code:
 
 ```csharp
 Device.CreateSerialMessagePort(Device.SerialPortNames.Com4, 
@@ -180,8 +175,7 @@ serialPort.Write(buffer);
 
 ### Encoding and Decoding Serial Port Messages
 
-Note that serial ports deal in `byte` arrays, rather than strings or characters, so any strings need to be converted to bytes. Typically, you'll want
-to use `Encoding.UTF8` or `Encoding.ASCII` encoding. 
+Note that serial ports deal in `byte` arrays, rather than strings or characters, so any strings need to be converted to bytes. Typically, you'll want to use `Encoding.UTF8` or `Encoding.ASCII` encoding.
 
 To turn a string into a `byte[]`, you can use the following call:
 
@@ -191,25 +185,13 @@ Encoding.UTF8.GetBytes("\r\n")
 
 ## Reading from a Serial Port
 
-`ISerialPort` and `ISerialMessage` port diverge greatly in their behavior in regards to reading from them. Serial is a legacy protocol technology 
-in which data comes in asynchronously and unlike messages in SPI or I2C, there is no standard message protocol. Typically, in legacy serial port 
-implementations the consumer is expected to either continuously poll the serial port buffer and pull off new data bytes, or wait for a serial
-data received event notification, and then pull bytes off the receive buffer.
+`ISerialPort` and `ISerialMessage` port diverge greatly in their behavior in regards to reading from them. Serial is a legacy protocol technology in which data comes in asynchronously and unlike messages in SPI or I2C, there is no standard message protocol. Typically, in legacy serial port implementations the consumer is expected to either continuously poll the serial port buffer and pull off new data bytes, or wait for a serial data received event notification, and then pull bytes off the receive buffer.
 
-Both of these approaches have massive drawbacks. Polling a serial port is processor intensive, as it relies on a loop that constantly checks for 
-new data. Waiting for an event to read from the buffer is more efficient, but both methods can be extremely problematic when actualy reading from 
-the buffer. The issue is that a serial port has a single receive buffer, and reading from that buffer removes the data from it. If multiple actors
-are reading from the buffer, then the each actor might only get fragments of the intended data, rendering the data invalid. Additionally, because
-messages are indeterminate in their termination, when the data received event comes in, the entire message data may not have arrived, so a data
-consumer would need to either continuously poll for more data until it can be determined that all the data has come in, or use advanced threading
-techniques to resume the reading thread when additional data has come in.
+Both of these approaches have massive drawbacks. Polling a serial port is processor intensive, as it relies on a loop that constantly checks for new data. Waiting for an event to read from the buffer is more efficient, but both methods can be extremely problematic when actually reading from the buffer. The issue is that a serial port has a single receive buffer, and reading from that buffer removes the data from it. If multiple actors are reading from the buffer, then the each actor might only get fragments of the intended data, rendering the data invalid. Additionally, because messages are indeterminate in their termination, when the data received event comes in, the entire message data may not have arrived, so a data consumer would need to either continuously poll for more data until it can be determined that all the data has come in, or use advanced threading techniques to resume the reading thread when additional data has come in.
 
 ### Reading Messages via `ISerialMessagePort`
 
-It is for this reason that we created the `ISerialMessagePort`, which handles all of the underlying concurrency issues on the receive buffer 
-and takes an asynchronous approach to serial messages. Simply define your message type during construction and then listen for incoming message 
-notifications. In this way, multiple consumers can listen for new data without concurrency issues, and all reading is handled efficiently, under
-the hood.
+It is for this reason that we created the `ISerialMessagePort`, which handles all of the underlying concurrency issues on the receive buffer and takes an asynchronous approach to serial messages. Simply define your message type during construction and then listen for incoming message notifications. In this way, multiple consumers can listen for new data without concurrency issues, and all reading is handled efficiently, under the hood.
 
 #### `MessageReceived` Event
 
@@ -232,7 +214,7 @@ void SerialPort_MessageReceived(object sender, SerialMessageData e)
 
 ## Reading from the Receive Buffer via `ClassicSerialPort`
 
-When data from the peripheral is received, it's placed in an internal [circular recieve buffer](https://en.wikipedia.org/wiki/Circular_buffer). The simplest way to read the data from that buffer is to call the [`Read(byte[] buffer, int offset, int count)` method](/docs/api/Meadow/Meadow.Hardware.ISerialPort.html#Meadow_Hardware_ISerialPort_Read_System_Byte___System_Int32_System_Int32_), passing in a buffer to read the bytes into, as well as the start index and the number of bytes to read. 
+When data from the peripheral is received, it's placed in an internal [circular receive buffer](https://en.wikipedia.org/wiki/Circular_buffer). The simplest way to read the data from that buffer is to call the [`Read(byte[] buffer, int offset, int count)` method](/docs/api/Meadow/Meadow.Hardware.ISerialPort.html#Meadow_Hardware_ISerialPort_Read_System_Byte___System_Int32_System_Int32_), passing in a buffer to read the bytes into, as well as the start index and the number of bytes to read.
 
 For example, the following code will read 7 bytes from the buffer:
 
@@ -249,9 +231,7 @@ As data is received by the serial port, a [`DataReceived` event](/docs/api/Meado
 
 ### `Read()` Warning
 
-Because the receive buffer is shared, and a single message might arrive in multiple chunks, each chunk associated with a `DataReceived` event, 
-care must be taken that there is only one consumer of the buffer, and that any reads are done in a critical section (i.e., C#'s `lock(object) { ... }` syntax).
-
+Because the receive buffer is shared, and a single message might arrive in multiple chunks, each chunk associated with a `DataReceived` event, care must be taken that there is only one consumer of the buffer, and that any reads are done in a critical section (i.e., C#'s `lock(object) { ... }` syntax).
 
 ### Additional APIs
 

--- a/docs/Meadow/Meadow_Basics/IO/Digital/index.md
+++ b/docs/Meadow/Meadow_Basics/IO/Digital/index.md
@@ -10,7 +10,6 @@ Digital IO is often referred to as _General Purpose, Input/Output_ or GPIO. GPIO
 
 For sample Meadow applications that illustrate the usage of digial ports, check out the [IO Sample apps in the Meadow.Core.Samples repo](https://github.com/WildernessLabs/Meadow.Core.Samples/tree/main/Source/Meadow.Core.Samples/IO).
 
-
 ## Digital Outputs
 
 _Setting_ the state of a _digital output_ is done using an implementation of the `IDigitalOutputPort` interface, available on any device that implements the `IDigitOutputController` interface, which provides a method called `CreateDigitalOutputPort`:
@@ -85,7 +84,7 @@ bool currentState = input.State;
 
 ### Interrupts
 
-Interrupts allow your application to be notified of the change of state of a digital input without having to poll the value. Enabling interrupts requires two things from your application: setting the `InterruptMode` of the `IDigitalInputPort` and then subscribing to notifications either via the `Changed` event, or using the `IObservable` pattern. 
+Interrupts allow your application to be notified of the change of state of a digital input without having to poll the value. Enabling interrupts requires two things from your application: setting the `InterruptMode` of the `IDigitalInputPort` and then subscribing to notifications either via the `Changed` event, or using the `IObservable` pattern.
 
 #### Example
 
@@ -106,7 +105,6 @@ input.Changed += (s, e) =>
 
 For more information, check out the [Events and IObservable guide](/Meadow/Meadow_Basics/Events_and_IObservable/).
 
-
 #### Debounce and Glitch Filtering
 
 Signal _noise_ is spurious signal changes on a circuit that are induced either via normal mechanical imperfections, such as push buttons or switches, or sometimes through electromagnetic radiation. This noise can case unwanted level change notifications.
@@ -126,29 +124,27 @@ To understand these settings, it helps to understand what these filters are.
 
 ##### Glitch Filter
 
-A glitch is a spurious change _before_ an intentional state change occurs. Because noise typically manifests itsef as spikes, the glitch filter specifies the minimum duration, in microseconds (µs), of an initial state change to persist before it's notified as an intentional state change, rather than a spurious one. 
+A glitch is a spurious change _before_ an intentional state change occurs. Because noise typically manifests itself as spikes, the glitch filter specifies the minimum duration, in microseconds (µs), of an initial state change to persist before it's notified as an intentional state change, rather than a spurious one.
 
-This filter can be used to ensure that noise doens't trigger an in interrupt. Set to `0` if no glitch filter is desired.
+This filter can be used to ensure that noise doesn't trigger an in interrupt. Set to `0` if no glitch filter is desired.
 
 ##### Debounce Filter
 
-A _bounce_ gets it's name from mechanical switches (like the common push button/tactile switch), and happens _after_ an intentional state change, like the pushing of a button, in which an actual, mechanical _bounce_ might cause the signal to change momentarily. The _debounce filter_ then specifies the duration, in microseconds (µs), of the time to ignore state changes after a state change has occurred. 
+A _bounce_ gets it's name from mechanical switches (like the common push button/tactile switch), and happens _after_ an intentional state change, like the pushing of a button, in which an actual, mechanical _bounce_ might cause the signal to change momentarily. The _debounce filter_ then specifies the duration, in microseconds (µs), of the time to ignore state changes after a state change has occurred.
 
 This filter can be used to prevent unwanted state changes due to noise. Set to `0` if no debounce filter is desired.
-
 
 #### Interrupt Groups
 
 One thing to bear in mind when creating interrupts on multiple pins is that input pins share _interrupt groups_, in which only one input within any given interrupt group can be enabled as an interrupt. So when choosing pins to use as interrupts, refer to the pinout diagram and make sure that for each interrupt you want to use, they're in a unique interrupt group:
 
-##### Meadow F7v2 Micro Pinout
+##### Meadow F7v2 Feather Pinout
 
 ![Meadow F7v2 pinout diagram showing pins used for multiple functions](/Common_Files/Meadow_F7v2_Micro_Pinout.svg){:standalone}
 
-##### Meadow F7v1 Micro Pinout
+##### Meadow F7v1 Feather Pinout
 
 ![Meadow F7v1 pinout diagram showing pins used for multiple functions](/Common_Files/Meadow_F7_Micro_Pinout.svg){:standalone}
-
 
 <!--
 ## Timing
@@ -211,9 +207,8 @@ PWM signals are frequently used to control the brightness of LEDs, as well as se
 
 Digital IO also includes built-in support for a host of different types of common digital [communication protocols](/Meadow/Meadow_Basics/IO/Digital/Protocols/) including:
 
-* **[I2C](/Meadow/Meadow_Basics/IO/Digital/Protocols/I2C)** 
+* **[I2C](/Meadow/Meadow_Basics/IO/Digital/Protocols/I2C)**
 * **[SPI](/Meadow/Meadow_Basics/IO/Digital/Protocols/SPI)** (Serial Peripheral Interface)
-* **[UART](/Meadow/Meadow_Basics/IO/Digital/Protocols/UART)** (Serial) 
+* **[UART](/Meadow/Meadow_Basics/IO/Digital/Protocols/UART)** (Serial)
 <!-- * **[CAN](/Meadow/Meadow_Basics/IO/Digital/Protocols/CAN)** -->
 <!-- * **[I2S](/Meadow/Meadow_Basics/IO/Digital/Protocols/I2S)** (Integrated Inter-IC Sound Bus) -->
-

--- a/docs/Meadow/Meadow_Basics/IO/Power/index.md
+++ b/docs/Meadow/Meadow_Basics/IO/Power/index.md
@@ -1,12 +1,12 @@
 ---
 layout: Meadow
 title: Power IO
-subtitle: Power administration on the F7 Micro Development board.
+subtitle: Power administration on the F7 Feather Development board.
 ---
 
-## Powering the Meadow F7 Micro
+## Powering the Meadow F7 Feather
 
-The Meadow F7 Micro development board is designed such that it can be powered by supplying the appropriate voltage to either the `USB` connector, or the `5V` or `3.3V` power rails. 
+The Meadow F7 Feather development board is designed such that it can be powered by supplying the appropriate voltage to either the `USB` connector, or the `5V` or `3.3V` power rails.
 
 ### Battery Charging Circuit
 
@@ -20,13 +20,13 @@ If you supply voltage only to the `3.3V` power rail, the board will operate as e
 
 ### Power Budget
 
-When powered by either `USB` connector or the `5V` rail, the amount of combined `3.3V` current available onboard (including the `3V3` power rail, MCUs, and IO peripherals) is limited, and is known as the _power budget_. 
+When powered by either `USB` connector or the `5V` rail, the amount of combined `3.3V` current available onboard (including the `3V3` power rail, MCUs, and IO peripherals) is limited, and is known as the _power budget_.
 
 When powered via the `USB` connector, the budget is limited only by the `3.3V` power regulator, which is good for `800mA` of output. However, on revision `1.c` of the board, when power input comes from the `5V` rail, it's limited by a diode that has a `500mA` maximum power throughput. Therefore, the onboard `3.3V` power budget is as follows:
 
 | Revision | Power Input | Budget  |
 |----------|-------------|---------|
-| `1.c`    | `USB`       | `800mA` | 
+| `1.c`    | `USB`       | `800mA` |
 | `1.c`    | `5V`        | `500mA` |
 | `1.d`    | `USB`       | `800mA` |
 | `1.d`    | `5V`        | `800mA` |
@@ -49,9 +49,9 @@ On the Meadow F7, there is a `25mA` per IO maximum, and a total maximum of `120m
 
 ##### Battery Charger Usage
 
-The battery charging circuit is hooked directly to the `USB` power rail. When powering Meadow via USB and charging a battery, the battery charging circut will pull up to `200mA`. This means you should subtract `200mA` from your USB power budget. For example, if you're powering Meadow with a USB power supply that can deliver `0.75A` at `5V`, you should subtract `200mA` from the USB power budget. The Meadow board will have `550mA` avaliable.
+The battery charging circuit is hooked directly to the `USB` power rail. When powering Meadow via USB and charging a battery, the battery charging circuit will pull up to `200mA`. This means you should subtract `200mA` from your USB power budget. For example, if you're powering Meadow with a USB power supply that can deliver `0.75A` at `5V`, you should subtract `200mA` from the USB power budget. The Meadow board will have `550mA` available.
 
-The battery charging circut is also connected to the `5V` rail via a diode. You can charge a battery when powering Meadow via the `5V` rail. However, this will cause up to `200mA` to flow through the `5V` rail reducing your `5V` power budget. This is important because Meadow has a current limit on the `5V` rail, `500mA` for `1.c` boards and `800mA` for `1.d` boards. You'll only be able to safely use and additional `300mA` for `1.c` boards and `600mA` for `1.d` boards regardless of the avalaible current of the external power supply.
+The battery charging circuit is also connected to the `5V` rail via a diode. You can charge a battery when powering Meadow via the `5V` rail. However, this will cause up to `200mA` to flow through the `5V` rail reducing your `5V` power budget. This is important because Meadow has a current limit on the `5V` rail, `500mA` for `1.c` boards and `800mA` for `1.d` boards. You'll only be able to safely use and additional `300mA` for `1.c` boards and `600mA` for `1.d` boards regardless of the available current of the external power supply.
 
 ## Solar + Battery Power
 
@@ -75,7 +75,7 @@ Note that as long as the board still has power, the RTC will continue to keep ti
 
 ### `3.3V` Power Rail (`3V3`)
 
-The `3.3V` power rail is exposed via the `3V3` header pin. 
+The `3.3V` power rail is exposed via the `3V3` header pin.
 
 ### Analog Reference (`AREF`)
 
@@ -109,5 +109,4 @@ The `5V` power rail is exposed via the `5V` header pin.
 ## Adding Power to External Peripherals
 
 [because of the limits on how much power the board can drive, it may be necessary to provide external power to certain peripherals, such as motors, relays, and other high power devices]
-
 -->

--- a/docs/Meadow/Meadow_Basics/IO/index.md
+++ b/docs/Meadow/Meadow_Basics/IO/index.md
@@ -57,7 +57,7 @@ For more information, see the [PWM guide](/Meadow/Meadow_Basics/IO/Digital/PWM/)
 
 Analog ports can operate at a range of voltages between `0V` and `3.3V`, which is especially useful when reading analog sensors that supply their data as a voltage reading, rather than a digital signal. For instance an analog temperature sensor that is able to detect temperatures from `0ºC` to `100ºC` might output a voltage of `1.6V` (halfway between `0V` and `3.3V`) for `50º`.
 
-For more information, see the [Analog IO guide](/Meadow/Meadow_Basics/IO/Analog/). 
+For more information, see the [Analog IO guide](/Meadow/Meadow_Basics/IO/Analog/).
 
 ### I/O Power Tolerance
 
@@ -67,15 +67,15 @@ Both the digital and analog I/O on the Meadow F7 board nominally operate at a ra
 
 For reading analog voltages higher than `3.3V`, see the [analog I/O guide](/Meadow/Meadow_Basics/IO/Analog/)
 
-### F7 Micro IO Pinout
+### F7 Feather IO Pinout
 
-GPIO ports are available via pins (as well as the onboard LED) on the Meadow F7 Micro, and many of these pins are actually overloaded to support multiple functions, as shown in the below illustrations.
+GPIO ports are available via pins (as well as the onboard LED) on the Meadow F7 Feather, and many of these pins are actually overloaded to support multiple functions, as shown in the below illustrations.
 
-#### Meadow F7v2 Micro Pinout
+#### Meadow F7v2 Feather Pinout
 
 ![Meadow F7v2 pinout diagram showing pins used for multiple functions](/Common_Files/Meadow_F7v2_Micro_Pinout.svg){:standalone}
 
-#### Meadow F7v1 Micro Pinout
+#### Meadow F7v1 Feather Pinout
 
 ![Meadow F7v1 pinout diagram showing pins used for multiple functions](/Common_Files/Meadow_F7_Micro_Pinout.svg){:standalone}
 
@@ -91,7 +91,7 @@ When working with IO in Meadow, there are three different terms/concepts to be a
 
 ### `IIOController`
 
-A device that supports IO (such as the F7 Micro device itself, or an external IO Expander) is represented by an `IIOController`, which exposes a `Pins` collection of `IPin` objects.
+A device that supports IO (such as the F7 Feather device itself, or an external IO Expander) is represented by an `IIOController`, which exposes a `Pins` collection of `IPin` objects.
 
 IO Devices are self describing with a mapping of `Device` > `Pins` > `Channels`. For instance, the following Meadow [sample code](https://github.com/WildernessLabs/Meadow_Samples/tree/master/Source/MeadowSamples/GpioInterrogation) enumerates all the pins and what type of IO is possible for each pin:
 
@@ -132,9 +132,9 @@ When interacting with peripherals, the actual control and interaction happens vi
 IDigitalOutputPort redLED = Device.CreateDigitalOutputPort(Device.Pins.OnboardLedRed);
 ```
 
-#### Meadow F7 Micro Pinout Table
+#### Meadow F7 Feather Pinout Table
 
-The following table lists all the accessible pins on the Meadow F7 Micro dev board and their functions:
+The following table lists all the accessible pins on the Meadow F7 Feather dev board and their functions:
 
 | Meadow Pin Name | MCU Pin Name | Digital Channel | Analog Channel | PWM Timer Channel | Interrupt Group |
 |-----------------|--------------|-----------------|----------------|-------------------|------------|
@@ -167,10 +167,10 @@ The following table lists all the accessible pins on the Meadow F7 Micro dev boa
 | OnboardLedGreen | PA1  | PA1  |           | 2 |    |
 | OnboardLedBlue  | PA0  | PA0  |           | 1 |    |
 
-#### Meadow F7v2 Micro Pinout Table
+#### Meadow F7v2 Feather Pinout Table
 
-| Meadow Pin Name | MCU Pin Name | Digital Channel | Analog Channel | PWM Timer Channel | Interrupt Group | 
-|-----------------|--------------|-----------------|----------------|-------------------|-----------------| 
+| Meadow Pin Name | MCU Pin Name | Digital Channel | Analog Channel | PWM Timer Channel | Interrupt Group |
+|-----------------|--------------|-----------------|----------------|-------------------|-----------------|
 | A00             | PA4  | PA4  | ADC1_IN4  |   | 4  |
 | A01             | PA5  | PA5  | ADC1_IN5  |   | 5  |
 | A02             | PA3  | PA3  | ADC1_IN3  |   | 3  |

--- a/docs/Meadow/Meadow_Basics/Status/index.md
+++ b/docs/Meadow/Meadow_Basics/Status/index.md
@@ -1,10 +1,10 @@
 ---
 layout: Meadow
-title: Meadow F7 Micro Beta Status
+title: Meadow F7 Feather Beta Status
 subtitle: Current feature and beta status.
 ---
 
-We are currently in [Meadow Release-Canditate 1.0](/Meadow/Release_Notes/Release-Candidates/).
+We are currently in [Meadow Release-Candidate 1.0](/Meadow/Release_Notes/Release-Candidates/).
 
 ## General IO Features
 
@@ -19,12 +19,11 @@ We are currently in [Meadow Release-Canditate 1.0](/Meadow/Release_Notes/Release
 | **CAN**              | No | Planned, v1.0 |
 | **DAC**              | No | Not implemented. Post-RTW |
 
-
 ## Communications
 
 | Feature          | Tested Working      | Notes                             |
 |------------------|---------------------|-----------------------------------|
-| WiFi	| Yes | All SSL certificates accepted. No SSL certificate management yet. |
+| Wi-Fi | Yes | All SSL certificates accepted. No SSL certificate management yet. |
 | Bluetooth | Yes |  |
 
 ## Other Features
@@ -32,7 +31,7 @@ We are currently in [Meadow Release-Canditate 1.0](/Meadow/Release_Notes/Release
 | Feature          | Tested Working      | Notes                             |
 |------------------|---------------------|-----------------------------------|
 | Debugging        | Yes                 |                |
-| Battery Charging  | Yes | |
+| Battery Charging | Yes | |
 | Battery Voltage Level | Yes | |
 | Power Management APIs | Yes | New in RC-1 |
 | Over-the-Air (OtA) Updates | Yes | New in RC-1 |

--- a/docs/Meadow/Meadow_Basics/Troubleshooting/index.md
+++ b/docs/Meadow/Meadow_Basics/Troubleshooting/index.md
@@ -14,7 +14,7 @@ It is important to ensure that you have a USB cable capable of providing data tr
 
 ## Unpowered USB Hub
 
-If you're having issues communicating with Meadow that is connected via an unpowered USB-Hub, try connecting Meadow directly to a USB port in your machine to ensure the USB-Hub is the issue. 
+If you're having issues communicating with Meadow that is connected via an unpowered USB-Hub, try connecting Meadow directly to a USB port in your machine to ensure the USB-Hub is the issue.
 
 As there are a large variety USB-hubs out there, we cant guarantee Meadow will work properly for all of them.
 
@@ -28,13 +28,13 @@ Scott Hanselman has written a good [blog post](https://www.hanselman.com/blog/Ho
 
 If you're getting the `Could not find a connected Meadow with the serial number #########`, the board might not have the correct Window drivers. To solve this, follow these steps:
 
-1. Open Device Manager
-1. Under USB Devices right click Meadow F7 Micro
+1. Open Device Manager.
+1. Under USB Devices right click Meadow F7 Micro.
 1. Uninstall Devices and click the check box.
-1. Unplug your Meadow
-1. Restart your PC
-1. Once PC is restarted, Plug in Meadow in Bootmode
-1. Run command "meadow flash os"
+1. Unplug your Meadow.
+1. Restart your PC.
+1. Once PC is restarted, plug in Meadow in bootloader mode.
+1. Run command `meadow flash os`.
 1. Wait until the line: "Having trouble putting Meadow in DFU Mode, please press RST button on Meadow and press enter to try again" appears.
 1. Open [Zadig](https://www.hanselman.com/blog/HowToFixDfuutilSTMWinUSBZadigBootloadersAndOtherFirmwareFlashingIssuesOnWindows.aspx) and replace the driver.
 1. Wait for the flash to finish.

--- a/docs/Meadow/Release_Notes/Beta6/index.md
+++ b/docs/Meadow/Release_Notes/Beta6/index.md
@@ -48,13 +48,13 @@ meadow flash erase
 
 ## Meadow.OS
 
-We've made a number of stability and functionality improvements in MeadowOS to enable support for the Core Compute Module, better Power APIs, improved network APIs, etc. Most of these improvements enable features in the **Meadow.Core** section below.
+We've made a number of stability and functionality improvements in MeadowOS to enable support for the Core-Compute Module, better Power APIs, improved network APIs, etc. Most of these improvements enable features in the **Meadow.Core** section below.
 
 One improvement of note - Meadow will now detect the executing hardware at runtime and throws an exception if the hardware in the `MeadowApp` signature doesn't match.
 
 ### Meadow.Core
 
-We're continuing to standardize and improve our API surface. And this release includes several improvements. We've also added support for the Meadow Core Compute module which gave us an opportunity to review, rethink, and standardize some of our existing APIs.
+We're continuing to standardize and improve our API surface. And this release includes several improvements. We've also added support for the Meadow Core-Compute module which gave us an opportunity to review, rethink, and standardize some of our existing APIs.
 
 #### Battery Info
 
@@ -88,9 +88,9 @@ Many calls that were deprecated with a warning in previous releases have been re
 
 `F7Micro` and `F7Microv2` class names have been deprecated and replaced with the more-appropriately named `F7FeatherV1` and `F7FeatherV2` classes. Backward support still exists and will give a deprecation error.  Future versions will escalate this to an error, so it is recommended you migrate your code.
 
-#### Support for the Core Compute Module
+#### Support for the Core-Compute Module
 
-This release adds support for the new Meadow Core Compute module with new `IMeadowDevice` and `IPinout` implementations. This support required refactoring of several base classes and interfaces.
+This release adds support for the new Meadow Core-Compute module with new `IMeadowDevice` and `IPinout` implementations. This support required refactoring of several base classes and interfaces.
 
 #### Other Changes
 


### PR DESCRIPTION
Evaluated anywhere we were using "F7 Micro" and updated to "F7 Feather" where it seemed more appropriate. Also same for "Core Compute Module" to "Core-Compute Module" to align with formal product name.

The only usage of "F7 Micro" left was in the [Troubleshooting section](http://beta-developer.wildernesslabs.co/Meadow/Meadow_Basics/Troubleshooting/#error-when-flashing-meadow-windows) where it accurately reflects the device name in Device Manager and Zadig.

(Sorry for the diff noise as I also fixed a lot of typos and Markdown warnings.)