### PR TITLE
Add Mono debug details

### DIFF
--- a/docs/Meadow/Meadow.OS/Configuration/OS_Device_Configuration/index.md
+++ b/docs/Meadow/Meadow.OS/Configuration/OS_Device_Configuration/index.md
@@ -80,14 +80,31 @@ MonoControl:
 
 ### Mono debug compilation
 
-In order to see line numbers in any runtime exceptions, pass the `--debug` parameter to the Mono command line.
+In order to see source filenames and line numbers in the stack trace of any runtime exceptions, you can pass the `--debug` parameter to the Mono command line. This won't currently change what is logged by Meadow for unhandled exceptions, but you will be able to find source code line numbers when debugging or specifically logging an exception's `StackTrace` property.
 
-NOTE: This setting should not be used in production Meadow apps. While debug compilation will provide line numbers, it will slow execution of your app.
+This setting can be combined with `--jit` and other Mono options.
+
+NOTE: This setting can have a performance impact in Meadow apps and should be avoided in production apps.
 
 ```yaml
 MonoControl:
   # Options to pass to Mono via the command line.
   Options: --debug --jit
+```
+
+With that in place, your exceptions will now show the source file location and line numbers in the stack trace of caught exceptions.
+
+```csharp
+try
+{
+    throw new NotImplementedException();
+}
+catch (Exception e)
+{
+    Console.WriteLine($"{e.StackTrace}");
+    // Example output without `--debug`: "[2022-10-26 22:42:32] Meadow StdOut:   at MeadowApplication.MeadowApp.Run () <0xc0df53f8 + 0x00014> in <596be8f53b23457caad22184d2aaf984>:0"
+    // Example output with `--debug`: [2022-10-27 07:57:05] Meadow StdOut:   at MeadowApplication20221026RC1.MeadowApp.Run () [0x0000d] in C:\...\MeadowApplication\MeadowApp.cs:23 
+}
 ```
 
 <!-- think we should cut this.

--- a/docs/Meadow/Meadow.OS/Configuration/OS_Device_Configuration/index.md
+++ b/docs/Meadow/Meadow.OS/Configuration/OS_Device_Configuration/index.md
@@ -22,6 +22,7 @@ Device:
 
 # Control how the .NET runtime executes your Meadow application, optionally enabling just-in-time (JIT) compilation instead of interpretation mode.
 MonoControl:
+  # Options to pass to Mono via the command line.
   Options: --jit
 
 # Control how the ESP coprocessor will start and operate.
@@ -75,6 +76,18 @@ This parameter determines if the .NET runtime executes your Meadow application v
 ```yaml
 MonoControl:
   Options: --jit
+```
+
+### Mono debug compilation
+
+In order to see line numbers in any runtime exceptions, pass the `--debug` parameter to the Mono command line.
+
+NOTE: This setting should not be used in production Meadow apps. While debug compilation will provide line numbers, it will slow execution of your app.
+
+```yaml
+MonoControl:
+  # Options to pass to Mono via the command line.
+  Options: --debug --jit
 ```
 
 <!-- think we should cut this.


### PR DESCRIPTION
Add documentation to show how to enable debug compilation via Mono to be able to see line numbers in runtime exceptions [at the cost of performance].

## Additional steps before submitting

- [x] [Not logged] Verify `--debug` output for a sample
  This appears to only impact exception stack trace data, not any of the default Meadow console logging.
- [x] [No] Verify if Meadow logs this setting for debugging unintentional `--debug` from output logs ([file feature request](https://github.com/WildernessLabs/Meadow_Issues/issues/new) if not)
  No logging is done to indicate that `--debug` was used. This would be a worthwhile line in case someone accidentally leaves it on.
- [x] [Seems fine] Verify good/bad if `--debug` is combined with `--jit`
  It doesn't seem like these two parameters have any issues being combined.
- [ ] Test and provide sample performance hit
