### PR TITLE
Add watchdog considerations

### DIFF
--- a/docs/Meadow/Meadow.OS/Automatic_Restarts/index.md
+++ b/docs/Meadow/Meadow.OS/Automatic_Restarts/index.md
@@ -65,3 +65,12 @@ The current `Device` property is available from within your `App` instance. If y
 ```csharp
 Resolver.Device.WatchdogEnable(TimeSpan.FromSeconds(10));
 ```
+
+## Watchdog Timer Considerations
+
+There are several elements to consider when implementing the watchdog time for your app.
+
+* As described in the API auto-complete documentation, the watchdog timer duration cannot exceed 32,768 milliseconds. If you try to enable the timer for longer than that, you will cause an `ArgumentOutofRangeException`.
+* If the watchdog timer system is enabled at any point, it cannot be disabled without resetting the Meadow board. This is a constraint of the underlying STM32's watchdog system, exposed for use by Meadow.
+* When [sleeping your Meadow](/Meadow/Meadow_Basics/Apps/Sleep/) in combination with the watchdog timer, sleep durations should not exceed the watchdog duration you choose. If you sleep longer than the watchdog timer duration, the watchdog system will trigger before Meadow can resume from sleep.
+    To work around the watchdog timer while sleeping for long periods of time, you would need to wake prior to the watchdog timer elapsing, potentially many times, to reset the watchdog before returning to sleep.


### PR DESCRIPTION
I'd ultimately like to include a sample piece of code for the long-sleep limitation, ideally embedded via Mirid from a compiled sample somewhere, but this would be a good start.