### PR TITLE
Fix broken image tag

### DIFF
--- a/docfx/api-override/Meadow.Foundation/Meadow.Foundation.Relays.Relay.md
+++ b/docfx/api-override/Meadow.Foundation/Meadow.Foundation.Relays.Relay.md
@@ -48,4 +48,5 @@ public override Task Run()
 
 ### Wiring Example
 
-<img src="../../API_Assets/Meadow.Foundation.Relays.Relay/Relay_Fritzing.svg" 
+<img src="../../API_Assets/Meadow.Foundation.Relays.Relay/Relay_Fritzing.svg"
+    style="width: 60%; display: block; margin-left: auto; margin-right: auto;" />


### PR DESCRIPTION
Hoping this fixes what's going on here currently:
![Docs screenshot showing an HTML image tag contents rather than an image itself.](https://user-images.githubusercontent.com/713665/205401283-83a6f023-141f-491f-8f0c-6f9cacb2afe5.png)
