### PR TITLE
Add new SdStorageSupported config info

### DIFF
--- a/docs/Meadow/Meadow.OS/Configuration/OS_Device_Configuration/index.md
+++ b/docs/Meadow/Meadow.OS/Configuration/OS_Device_Configuration/index.md
@@ -17,7 +17,8 @@ Consider the following sample config file:
 Device:
     # Name of the device on the network.
     Name: MeadowF7V2_ConfigSample
-
+    # Is SD card hardware present on this hardware build (e.g., Core-Compute module with SD add-on)? Optional; default value is `false`.
+    SdStorageSupported: false
 #===============================================================================
 
 # Control how the .NET runtime executes your Meadow application, optionally enabling just-in-time (JIT) compilation instead of interpretation mode.
@@ -68,6 +69,23 @@ The `Device` section contains configurable properties for the system in general.
 This is the name that will show on the network.
 
 Default value: MeadowF7
+
+```yaml
+Device:
+    Name: MeadowF7V2_ConfigSample
+```
+
+### Device `SdStorageSupported`
+
+Used to indicate whether SD card hardware is present where this project is deployed to ensure that SD card support is configured in the Meadow OS. Set this value to true if you are working on a Meadow hardware configuration using SD card hardware. For example, on the Core-Compute module with the SD card add-on, set this configuration to `true` if you are writing or reading from an SD card.
+
+Default value: false
+
+```yaml
+Device:
+    # Enable if your Meadow build is using SD card hardware.
+    SdStorageSupported: true
+```
 
 ### JIT compilation mode
 

--- a/docs/Meadow/Meadow.OS/Core-Compute_SD_Card/index.md
+++ b/docs/Meadow/Meadow.OS/Core-Compute_SD_Card/index.md
@@ -8,6 +8,18 @@ The Meadow Core-Compute Development Kit includes an SD card add-on, and one can 
 
 There is an event subscription system to monitor for external storage events in your Meadow app. And, from there, file operations can be done with the `System.IO` API as described in the [File System docs](/Meadow/Meadow.OS/File_System/).
 
+## Enable SD card hardware support
+
+Before writing or reading from an SD card, we need to tell the Meadow OS that we have SD card hardware available on our project build. To do this, you will need to set the **Device** > **SdStorageSupported** configuration value to `true` in the **meadow.config.yaml** file for your project.
+
+```yaml
+Device:
+    # Enable if your Meadow build is using SD card hardware.
+    SdStorageSupported: true
+```
+
+For more information about this setting, read the details in the [OS & Device Configuration](/Meadow/Meadow.OS/Configuration/OS_Device_Configuration/) documentation.
+
 ## Check for external storage devices
 
 If your Meadow device might have external storage at some point while your app is running, you can find it by iterating over your device's external storage items.


### PR DESCRIPTION
Upcoming release requires informing the Meadow OS when SD card hardware is present and needed. This adds the `SdStorageSupported` config information to the `meadow.config.yaml` docs.