### PR TITLE
WaveShare API overrides

### DIFF
--- a/docfx/api-override/Meadow.Foundation/Meadow.Foundation.Displays.ePaper.Epd1in54.md
+++ b/docfx/api-override/Meadow.Foundation/Meadow.Foundation.Displays.ePaper.Epd1in54.md
@@ -1,0 +1,6 @@
+---
+uid: Meadow.Foundation.Displays.ePaper.Epd1in54
+remarks: *content
+---
+
+This is a wrapper driver class for the `Ssd1608` display controller driver that this WaveShare display uses internally. For more details, consult that [`Ssd1608` driver](/docs/api/Meadow.Foundation/Meadow.Foundation.Displays.Ssd1608.html).

--- a/docfx/api-override/Meadow.Foundation/Meadow.Foundation.Displays.ePaper.Epd1in54b.md
+++ b/docfx/api-override/Meadow.Foundation/Meadow.Foundation.Displays.ePaper.Epd1in54b.md
@@ -1,0 +1,6 @@
+---
+uid: Meadow.Foundation.Displays.ePaper.Epd1in54b
+remarks: *content
+---
+
+This is a wrapper driver class for the `Il0376F` display controller driver that this WaveShare display uses internally. For more details, consult that [`Il0376F` driver](/docs/api/Meadow.Foundation/Meadow.Foundation.Displays.Il0376F.html).

--- a/docfx/api-override/Meadow.Foundation/Meadow.Foundation.Displays.ePaper.Epd1in54c.md
+++ b/docfx/api-override/Meadow.Foundation/Meadow.Foundation.Displays.ePaper.Epd1in54c.md
@@ -1,0 +1,6 @@
+---
+uid: Meadow.Foundation.Displays.ePaper.Epd1in54c
+remarks: *content
+---
+
+This is a wrapper driver class for the `Il0376F` display controller driver that this WaveShare display uses internally. For more details, consult that [`Il0376F` driver](/docs/api/Meadow.Foundation/Meadow.Foundation.Displays.Il0376F.html).

--- a/docfx/api-override/Meadow.Foundation/Meadow.Foundation.Displays.ePaper.Epd2in13.md
+++ b/docfx/api-override/Meadow.Foundation/Meadow.Foundation.Displays.ePaper.Epd2in13.md
@@ -1,0 +1,6 @@
+---
+uid: Meadow.Foundation.Displays.ePaper.Epd2in13
+remarks: *content
+---
+
+This is a wrapper driver class for the `Il3897` display controller driver that this WaveShare display uses internally. For more details, consult that [`Il3897` driver](/docs/api/Meadow.Foundation/Meadow.Foundation.Displays.Il3897.html).

--- a/docfx/api-override/Meadow.Foundation/Meadow.Foundation.Displays.ePaper.Epd2in13b.md
+++ b/docfx/api-override/Meadow.Foundation/Meadow.Foundation.Displays.ePaper.Epd2in13b.md
@@ -1,0 +1,6 @@
+---
+uid: Meadow.Foundation.Displays.ePaper.Epd2in13b
+remarks: *content
+---
+
+This is a wrapper driver class for the `Il0373` display controller driver that this WaveShare display uses internally. For more details, consult that [`Il0373` driver](/docs/api/Meadow.Foundation/Meadow.Foundation.Displays.Il0373.html).

--- a/docfx/api-override/Meadow.Foundation/Meadow.Foundation.Displays.ePaper.Epd2in13b_V4.md
+++ b/docfx/api-override/Meadow.Foundation/Meadow.Foundation.Displays.ePaper.Epd2in13b_V4.md
@@ -1,0 +1,6 @@
+---
+uid: Meadow.Foundation.Displays.ePaper.Epd2in13b_V4
+remarks: *content
+---
+
+This is a wrapper driver class for the `Il0373` display controller driver that this WaveShare display uses internally. For more details, consult that [`Il0373` driver](/docs/api/Meadow.Foundation/Meadow.Foundation.Displays.Il0373.html).

--- a/docfx/api-override/Meadow.Foundation/Meadow.Foundation.Displays.ePaper.Epd2in7b.md
+++ b/docfx/api-override/Meadow.Foundation/Meadow.Foundation.Displays.ePaper.Epd2in7b.md
@@ -1,0 +1,6 @@
+---
+uid: Meadow.Foundation.Displays.ePaper.Epd2in7b
+remarks: *content
+---
+
+This is a wrapper driver class for the `Il91874` display controller driver that this WaveShare display uses internally. For more details, consult that [`Il91874` driver](/docs/api/Meadow.Foundation/Meadow.Foundation.Displays.Il91874.html).

--- a/docfx/api-override/Meadow.Foundation/Meadow.Foundation.Displays.ePaper.Epd2in9.md
+++ b/docfx/api-override/Meadow.Foundation/Meadow.Foundation.Displays.ePaper.Epd2in9.md
@@ -1,0 +1,6 @@
+---
+uid: Meadow.Foundation.Displays.ePaper.Epd2in9
+remarks: *content
+---
+
+This is a wrapper driver class for the `Ssd1608` display controller driver that this WaveShare display uses internally. For more details, consult that [`Ssd1608` driver](/docs/api/Meadow.Foundation/Meadow.Foundation.Displays.Ssd1608.html).

--- a/docfx/api-override/Meadow.Foundation/Meadow.Foundation.Displays.ePaper.Epd2in9b.md
+++ b/docfx/api-override/Meadow.Foundation/Meadow.Foundation.Displays.ePaper.Epd2in9b.md
@@ -1,0 +1,6 @@
+---
+uid: Meadow.Foundation.Displays.ePaper.Epd2in9b
+remarks: *content
+---
+
+This is a wrapper driver class for the `Il0373` display controller driver that this WaveShare display uses internally. For more details, consult that [`Il0373` driver](/docs/api/Meadow.Foundation/Meadow.Foundation.Displays.Il0373.html).

--- a/docfx/api-override/Meadow.Foundation/Meadow.Foundation.Displays.ePaper.Epd4in2bc.md
+++ b/docfx/api-override/Meadow.Foundation/Meadow.Foundation.Displays.ePaper.Epd4in2bc.md
@@ -1,0 +1,6 @@
+---
+uid: Meadow.Foundation.Displays.ePaper.Epd4in2bc
+remarks: *content
+---
+
+This is a wrapper driver class for the `Il0398` display controller driver that this WaveShare display uses internally. For more details, consult that [`Il0398` driver](/docs/api/Meadow.Foundation/Meadow.Foundation.Displays.Il0398.html).


### PR DESCRIPTION
This will add an override detailing the underlying driver for the WaveShare drivers that are just wrappers for other display drivers.