### PR TITLE
RC-3 (v0.9.6.3) moved Device.SetClock() to Device.PlatformOS.SetClock()

### DIFF
--- a/docs/Meadow/Meadow.OS/RTC/index.md
+++ b/docs/Meadow/Meadow.OS/RTC/index.md
@@ -11,7 +11,7 @@ The STM32F7 is equipped with a real-time clock (RTC), which, when set, will reta
 To use Meadow's RTC module, simply set the time with the *SetClock* method:
 
 ```csharp
-Device.SetClock(new DateTime(
+Device.PlatformOS.SetClock(new DateTime(
     year: 2021, 
     month: 04, 
     day: 05, 


### PR DESCRIPTION
Upgraded to RC-3 (v0.9.6.3) this evening - it broke all my apps using SetClock().
Used the object browser to discover that SetClock has been moved from Device.SetClock() to Device.PlatformOS.SetClock()
