### PR TITLE
RC-3 (v0.9.6.3) moved Device.SetClock() to Device.PlatformOS.SetClock()

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -9,7 +9,7 @@ name: Deploy Jekyll site to beta site
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["master"]
+    branches: ["main"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/docs/Meadow/Meadow_Basics/Apps/Sleep/index.md
+++ b/docs/Meadow/Meadow_Basics/Apps/Sleep/index.md
@@ -15,10 +15,10 @@ Device.PlatformOS.Sleep(TimeSpan.FromSeconds(5));
 
 If you provide a `DateTime`, Meadow will sleep until that time.
 
-In order for this to work properly, you must [set the current date](../../Meadow.OS/RTC) via the `Device.SetClock` method.
+In order for this to work properly, you must [set the current date](../../Meadow.OS/RTC) via the `Device.PlatformOS.SetClock` method.
 
 ```csharp
-Device.SetClock(new DateTime(2022, 10, 19, 21, 58, 27));
+Device.PlatformOS.SetClock(new DateTime(2022, 10, 19, 21, 58, 27));
 ...
 // Put Meadow to sleep until this time tomorrow.
 Device.PlatformOS.Sleep(DateTime.Now.AddDays(1));


### PR DESCRIPTION
Upgraded to RC-3 (v0.9.6.3) this evening - it broke all my apps using SetClock(). 
Used the object browser to discover that SetClock has been moved from Device.SetClock() to Device.PlatformOS.SetClock()