### PR TITLE
Update Device.SetClock to use Device.PlatformOS

### DIFF
--- a/docs/Meadow/Meadow.OS/RTC/index.md
+++ b/docs/Meadow/Meadow.OS/RTC/index.md
@@ -11,7 +11,7 @@ The STM32F7 is equipped with a real-time clock (RTC), which, when set, will reta
 To use Meadow's RTC module, simply set the time with the *SetClock* method:
 
 ```csharp
-Device.SetClock(new DateTime(
+Device.PlatformOS.SetClock(new DateTime(
     year: 2021, 
     month: 04, 
     day: 05, 

--- a/docs/Meadow/Meadow_Basics/Apps/Sleep/index.md
+++ b/docs/Meadow/Meadow_Basics/Apps/Sleep/index.md
@@ -15,10 +15,10 @@ Device.PlatformOS.Sleep(TimeSpan.FromSeconds(5));
 
 If you provide a `DateTime`, Meadow will sleep until that time.
 
-In order for this to work properly, you must [set the current date](../../Meadow.OS/RTC) via the `Device.SetClock` method.
+In order for this to work properly, you must [set the current date](../../Meadow.OS/RTC) via the `Device.PlatformOS.SetClock` method.
 
 ```csharp
-Device.SetClock(new DateTime(2022, 10, 19, 21, 58, 27));
+Device.PlatformOS.SetClock(new DateTime(2022, 10, 19, 21, 58, 27));
 ...
 // Put Meadow to sleep until this time tomorrow.
 Device.PlatformOS.Sleep(DateTime.Now.AddDays(1));


### PR DESCRIPTION
The `SetClock` method has moved out of the top-level `Device` into `Device.PlatformOS`