### PR TITLE
Update SetClock to new namespace

### DIFF
--- a/docs/Meadow/Meadow.OS/RTC/index.md
+++ b/docs/Meadow/Meadow.OS/RTC/index.md
@@ -8,10 +8,10 @@ The STM32F7 is equipped with a real-time clock (RTC), which, when set, will reta
 
 # Using
 
-To use Meadow's RTC module, simply set the time with the *SetClock* method:
+To use Meadow's RTC module, simply set the time with the device platform's *SetClock* method:
 
 ```csharp
-Device.SetClock(new DateTime(
+Device.PlatformOS.SetClock(new DateTime(
     year: 2021, 
     month: 04, 
     day: 05, 


### PR DESCRIPTION
Fixes #255 in docs, but still requires changes to Hackster.

@jorgedevs Can you update the `Device.SetClock` uses here to align with the updated [sample source](https://github.com/WildernessLabs/Meadow.Project.Samples/blob/main/Source/Hackster/MeadowClock/MeadowApp.cs#L44-L58) using `Device.PlatformOS.SetClock`.