### PR TITLE
Add login prereq and Markdown adjustments

### DIFF
--- a/docs/Meadow/Meadow.OS/Configuration/Application_Settings_Configuration/index.md
+++ b/docs/Meadow/Meadow.OS/Configuration/Application_Settings_Configuration/index.md
@@ -59,6 +59,25 @@ Logging:
 }
 ```
 
+### Enable Meadow.Cloud Over-the-Air (OtA) updates
+
+To allow over-the-air (OtA) updates to your Meadow application, add the following configuration to your application's `app.config.yaml` or `app.config.json` file.
+
+```yaml
+Update:
+  Enabled: true
+```
+
+```json
+{
+    "Update": {
+        "Enabled": true
+    }
+}
+```
+
+You can learn more about enabling and responding to OtA updates in your Meadow application from the [Over-the-Air Updates documentation](/Meadow/Meadow.OS/Updates/).
+
 ### Custom Developer Application Settings
 
 You can also configure custom application settings that can then be retrieved at runtime through a strongly-typed system.

--- a/docs/Meadow/Meadow.OS/Updates/index.md
+++ b/docs/Meadow/Meadow.OS/Updates/index.md
@@ -11,9 +11,11 @@ Over-the-Air (OtA) updates are finally here! This is our first full stack featur
 ## Provision Device
 
 First, you need to register your device on Meadow.Cloud.
+
 * Visit [https://www.meadowcloud.co](https://www.meadowcloud.co) to setup your Meadow.Cloud account.
-* Connect your meadow device.
-* Via Meadow CLI, run: `meadow device provision`. This will take a couple minutes to complete. Visit to [https://www.meadowcloud.co/devices](https://www.meadowcloud.co/devices) to verify your device was successfully added.
+* Connect your Meadow device.
+* Ensure you are signed in to Meadow.Cloud for command-line use. Via Meadow.CLI, run: `meadow cloud login`. This will launch a web browser to sign in to Wilderness Labs with the account you set up for Meadow.Cloud.
+* Via Meadow.CLI, run: `meadow device provision`. This will take a couple minutes to complete. Visit to [https://www.meadowcloud.co/devices](https://www.meadowcloud.co/devices) to verify your device was successfully added.
 
 ## Enable Update Service in Meadow.Core
 
@@ -21,63 +23,64 @@ By default, OtA is not enabled. Follow the steps to enable OtA in your applicati
 
 * In `app.config.yaml`, add the following:
 
-```
-Update:
-  Enabled: true
-```
+    ```yaml
+    Update:
+      Enabled: true
+    ```
 
 * (Optional) To see more detailed output, enable trace logging by adding the following lines in `app.config.yaml`:
 
-```
-Logging:
-  LogLevel:
-    Default: "Trace"
-```
+    ```yaml
+    Logging:
+      LogLevel:
+          Default: "Trace"
+    ```
 
 * Next, add event handlers for downloading and applying the updates.
 
-```
-using Meadow.Update;
-...
-public override async Task Run()
-{
-    var svc = Resolver.Services.Get<IUpdateService>() as Meadow.Update.UpdateService;
-    svc.ClearUpdates(); // uncomment to clear persisted info
-
-    svc.OnUpdateAvailable += (updateService, info) =>
-    {
-        Resolver.Log.Info("Update available!");
-
-        // queue it for retreival "later"
-        Task.Run(async () =>
-        {
-            await Task.Delay(5000);
-            updateService.RetrieveUpdate(info);
-        });
-    };
-
-    svc.OnUpdateRetrieved += (updateService, info) =>
-    {
-        Resolver.Log.Info("Update retrieved!");
-
-        Task.Run(async () =>
-        {
-            await Task.Delay(5000);
-            updateService.ApplyUpdate(info);
-        });
-    };
-
+    ```csharp
+    using Meadow.Update;
     ...
+    public override async Task Run()
+    {
+        var svc = Resolver.Services.Get<IUpdateService>() as Meadow.Update.UpdateService;
+        svc.ClearUpdates(); // uncomment to clear persisted info
 
-}
-```
-This code adds event handers to download the new package, `updateService.RetrieveUpdate(info);`. and send the new file(s) to the bootloader, `updateService.ApplyUpdate(info);`
+        svc.OnUpdateAvailable += (updateService, info) =>
+        {
+            Resolver.Log.Info("Update available!");
+
+            // queue it for retreival "later"
+            Task.Run(async () =>
+            {
+                await Task.Delay(5000);
+                updateService.RetrieveUpdate(info);
+            });
+        };
+
+        svc.OnUpdateRetrieved += (updateService, info) =>
+        {
+            Resolver.Log.Info("Update retrieved!");
+
+            Task.Run(async () =>
+            {
+                await Task.Delay(5000);
+                updateService.ApplyUpdate(info);
+            });
+        };
+
+        ...
+
+    }
+    ```
+
+    This code adds event handers to download the new package, `updateService.RetrieveUpdate(info);`. and send the new file(s) to the bootloader, `updateService.ApplyUpdate(info);`
 
 ## MPAK Creation
 
 An .mpak file is a bundle that includes application and OS files. We'll use the application we created in the previous section.
 
-* Deploy the OtA enabled application to a device. (Currently, the linker only runs during a deployment. This step can be skipped [once this gets fixed](https://github.com/WildernessLabs/Meadow.CLI/issues/287).)
+* Deploy the OtA-enabled application to a device. (Currently, the linker only runs during a deployment. This step can be skipped [once this gets fixed](https://github.com/WildernessLabs/Meadow.CLI/issues/287).)
 * Run `meadow package create -p your_app_folder/bin/Debug/netstandard2.1/postlink_bin -v 0.9.8.1`. This creates a .mpak file with the contents of your application and binaries for the OS version specified.
 * To upload your newly created .mpak to Meadow.Cloud, run `meadow package upload -p your_package_id`. Visit [https://www.meadowcloud.co/packages](https://www.meadowcloud.co/packages) to verify your package was successfully uploaded.
 
@@ -85,7 +88,3 @@ An .mpak file is a bundle that includes application and OS files. We'll use the 
 
 * To publish via CLI, run `meadow package publish -p your_package_id`.  
 * To publish via Web, go to [https://www.meadowcloud.co/packages](https://www.meadowcloud.co/packages) and click `Publish`.
-
-
-
-

--- a/docs/Meadow/Meadow.OS/Updates/index.md
+++ b/docs/Meadow/Meadow.OS/Updates/index.md
@@ -21,22 +21,22 @@ First, you need to register your device on Meadow.Cloud.
 
 By default, OtA is not enabled. Follow the steps to enable OtA in your application.  
 
-* In `app.config.yaml`, add the following:
+1. In `app.config.yaml`, add the following:
 
     ```yaml
     Update:
       Enabled: true
     ```
 
-* (Optional) To see more detailed output, enable trace logging by adding the following lines in `app.config.yaml`:
+    * (Optional) To see more detailed output, enable trace logging by adding the following lines in `app.config.yaml`:
 
-    ```yaml
-    Logging:
-      LogLevel:
-          Default: "Trace"
-    ```
+        ```yaml
+        Logging:
+          LogLevel:
+              Default: "Trace"
+        ```
 
-* Next, add event handlers for downloading and applying the updates.
+1. Next, add event handlers for downloading and applying the updates.
 
     ```csharp
     using Meadow.Update;


### PR DESCRIPTION
* Added prereq for `meadow cloud login`
* Made code blocks part of their respective steps, now numbered
* Cleaned up Markdown warnings
* Added config details to Application Config page with link to OtA docs