### PR TITLE
Give prod deploy unique name

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -4,7 +4,7 @@
 # documentation.
 
 # Sample workflow for building and deploying a Jekyll site to GitHub Pages
-name: Deploy Jekyll site to beta site
+name: Deploy Jekyll site to production site
 
 on:
   # Runs on pushes targeting the default branch


### PR DESCRIPTION
The production deployment appeared with the same name as the beta deploy in the Actions list: `Deploy Jekyll site to beta site` with beta even in the name of the production deployment. This gives the production deployment a unique name that reflects the environment.

![image](https://github.com/WildernessLabs/Documentation/assets/713665/c7e93322-0597-499b-a6a1-f4af0c4f6fa7)
