### PR TITLE
Switch DevCamp from registration to recording list

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ layout: Home
 ## Past Events
 
 ### May 18-19, 2023
-**[Wilderness Labs DevCamp 2023](https://www.eventbrite.com/e/devcamp-2023-virtual-tickets-597113842577)** - We’re excited to announce that we’re hosting our first ever, in-person, DevCamp in Seattle on May 18th/19th, 2023. Join us to be the first to hear some awesome Meadow news. Registration is free. Day 1 will be an in-person portion and is invite-only. Day 2 will be virtual and open to everyone!
+**[Wilderness Labs DevCamp 2023](https://youtube.com/playlist?list=PLoP9Fu9zn7qZty1H1Jvd9-TQ7ePc3WNno)** - We’re excited to announce that we’re hosting our first ever, in-person, DevCamp in Seattle on May 18th/19th, 2023. Join us to be the first to hear some awesome Meadow news. Registration is free. Day 1 will be an in-person portion and is invite-only. Day 2 will be virtual and open to everyone!
 
 ### 2022.February.17th
 **[Meadow - A Modern IoT Hardware and Software Development Platform](https://www.meetup.com/DeveloperSouthCoast/events/283314062/)** - This session will look at the extensive collection of libraries and demonstrate how they can be used to perform a variety of tasks including, getting started, connecting to a sensor and recording data, and controlling hardware based on those readings.


### PR DESCRIPTION
Switching the past event link to the YouTube recordings.

We are still waiting on a unified DevCamp 2023 playlist (vs. the current Day 1 and Day 2 lists), but this is roughly the edit we need.