### PR TITLE
Fix Cell sample style

### DIFF
--- a/docs/Meadow/Meadow.OS/Cellular/index.md
+++ b/docs/Meadow/Meadow.OS/Cellular/index.md
@@ -112,7 +112,7 @@ To check if you established a connection, you can use the `meadow listen` CLI co
 
 You can check the Cell connection status by accessing the `IsConnected` property present in the Cell Network Adapter, as in the following example:
 
-```Csharp
+```csharp
 var cell = Device.NetworkAdapters.Primary<ICellNetworkAdapter>();
 
 if (cell.IsConnected)


### PR DESCRIPTION
Just to replace the ```Csharp``` for ```csharp``` that seemed to affect the sample code style