### PR TITLE
Fix Action name mismatch

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -4,7 +4,7 @@
 # documentation.
 
 # Sample workflow for building and deploying a Jekyll site to GitHub Pages
-name: Deploy Jekyll site to beta site
+name: Deploy Jekyll site to production site
 
 on:
   # Runs on pushes targeting the default branch


### PR DESCRIPTION
This Action was named identically to the [beta one](https://github.com/WildernessLabs/Documentation/blob/main/.github/workflows/jekyll-beta.yml), which could cause some confusion.

This should fix that in the Action list, too.

<img width="243" alt="image" src="https://github.com/WildernessLabs/Documentation/assets/713665/f202fc48-7df0-42c6-82e2-143614644cd1">
