### PR TITLE
Fix small issue on the reserved pin name

### DIFF
--- a/docs/Meadow/Meadow.OS/Cellular/index.md
+++ b/docs/Meadow/Meadow.OS/Cellular/index.md
@@ -56,7 +56,7 @@ Device:
     ReservedPins: I9;H13;C7
 ```
 
-> **Notes**: You can find the pins `I9`, `H13` and `C7` as `D00`, `D01` and `D10` on the **Meadow F7v2 Feather**, respectively. If you use different pins, you should reserve the corresponding ones, according to the pinout denifition present in the [**Meadow F7v2 Feather** datasheet](http://developer.wildernesslabs.co/Meadow/Meadow_Basics/Hardware/Wilderness_Labs_Meadow_F7v2_Datasheet.pdf). For instance, if you want to utilize the `A02` **Meadow F7v2 Feather** pin to turn on the module, you should reserve the corresponding `A03` MCU pin.
+> **Notes**: You can find the pins `I9`, `H13` and `C7` as `D00`, `D01` and `D10` on the **Meadow F7v2 Feather**, respectively. If you use different pins, you should reserve the corresponding ones, according to the pinout denifition present in the [**Meadow F7v2 Feather** datasheet](http://developer.wildernesslabs.co/Meadow/Meadow_Basics/Hardware/Wilderness_Labs_Meadow_F7v2_Datasheet.pdf). For instance, if you want to utilize the `A02` **Meadow F7v2 Feather** pin to turn on the module, you should reserve the corresponding `A3` MCU pin.
 
 ## Hardware configuration
 


### PR DESCRIPTION
Minor fix related to correcting the Reserved Pin name, which should be `A3` instead of `A03`.