### PR TITLE
Remove Tsa9548a exclusion to test DocFX

### DIFF
--- a/docfx/docfx.json
+++ b/docfx/docfx.json
@@ -27,7 +27,6 @@
             "/Source/Meadow.Foundation.Peripherals/**/Datasheet/**",
             "/Source/Meadow.Foundation.Peripherals/**/Sample/**",
             "/Source/Meadow.Foundation.Peripherals/**/Samples/**",
-            "/Source/Meadow.Foundation.Peripherals/ICs.IOExpanders.Tca9548A/**",
             "/Source/Meadow.Foundation.Libraries_and_Frameworks/**/Driver/bin/**",
             "/Source/Meadow.Foundation.Libraries_and_Frameworks/**/Driver/obj/**",
             "/Source/Meadow.Foundation.Libraries_and_Frameworks/**/Sample/**",


### PR DESCRIPTION
Trying to resolve broken link for Tsa9548a.
https://developer.wildernesslabs.co/Meadow/Meadow.Foundation/Peripherals/#ics

Currently failing for this URL because we were excluding it.
http://developer.wildernesslabs.co/docs/api/Meadow.Foundation/Meadow.Foundation.ICs.IOExpanders.Tca9548a.html