### PR TITLE
Fix broken Meadow.Hardware link

### DIFF
--- a/docfx/api/Meadow/index.md
+++ b/docfx/api/Meadow/index.md
@@ -8,7 +8,7 @@ To search, use the filer on the hand navigation.
 
 Here are some important API docs:
 
-* **[`Meadow.Hardware` namespace](/api/Meadow.Foundation/Meadow.Hardware.html)** - Docs related to IO and ports.
+* **[`Meadow.Hardware` namespace](/docs/api/Meadow/Meadow.Hardware.html)** - Docs related to IO and ports.
 
 ### Other Documentation
 

--- a/docfx/api/Meadow/index.md
+++ b/docfx/api/Meadow/index.md
@@ -8,8 +8,7 @@ To search, use the filer on the hand navigation.
 
 Here are some important API docs:
 
-* **[`Meadow.Hardware` namespace](/api/Meadow/Meadow.Hardware.html)** - Docs related to IO and ports.
-
+* **[`Meadow.Hardware` namespace](/api/Meadow.Foundation/Meadow.Hardware.html)** - Docs related to IO and ports.
 
 ### Other Documentation
 
@@ -24,6 +23,3 @@ Here are some common Meadow.Foundation guides:
 * **[Meadow.Foundation Getting Started](/Meadow/Meadow.Foundation/Getting_Started/)** - Beginning guide to working with Meadow.Foundation.
 * **[Meadow.Foundation Peripheral Drivers List](/Meadow/Meadow.Foundation/Peripherals/)** - A comprehensive list of all peripheral drivers in Meadow.Foundation.
 * **[Meadow.Foundation Libraries and Frameworks](/Meadow/Meadow.Foundation/Libraries_and_Frameworks/)** - A list of libraries and frameworks in Meadow.Foundation such as the MicroGraphics and TextDisplayMenu libraries.
-
-
-


### PR DESCRIPTION
[Fixes #506]

Found the API page under Meadow.Foundation, which appears to be how our DocFX system is generating things.