### PR TITLE
Generate API docs for Meadow.Contracts, .Logging, and .Units

### DIFF
--- a/docfx/docfx.json
+++ b/docfx/docfx.json
@@ -7,6 +7,24 @@
             "/**.csproj"
           ],
           "src": "../../Meadow.Core/source/Meadow.Core"
+        },
+        {
+          "files": [
+            "/**.csproj"
+          ],
+          "src": "../../Meadow.Contracts/Source/Meadow.Contracts"
+        },
+        {
+          "files": [
+            "/**.csproj"
+          ],
+          "src": "../../Meadow.Units/Source/Meadow.Units"
+        },
+        {
+          "files": [
+            "/**.csproj"
+          ],
+          "src": "../../Meadow.Logging/source/Meadow.Logging"
         }
       ],
       "dest": "api/Meadow",


### PR DESCRIPTION
We were cloning the repos for the DocFX .NET build side of things, but weren't telling it to generate docs pages from those repos.