### PR TITLE
Update links to folder changes

### DIFF
--- a/docs/Hardware/Reference/BitBanging/index.md
+++ b/docs/Hardware/Reference/BitBanging/index.md
@@ -11,7 +11,7 @@ BitBanging is a technique for controlling the output pins of a microcontroller. 
 * Unsupported protocol (for example the communication protocol for the [DHT22](https://www.adafruit.com/product/385) temperature and humidity sensor)
 * All of the serial peripherals are in use for other purposes
 
-The guide on using the [74595 shift register](/Hardware/Reference/Components/ShiftRegister74595/) contains some simple BitBanging code:
+The guide on using the [74595 shift register](/Hardware/Circuits/Components/ShiftRegister74595/) contains some simple BitBanging code:
 
 ```csharp
 private static void BitBang(OutputPort data, OutputPort clock, byte value)

--- a/docs/Hardware/Tutorials/Electronics/Part4/Resistance/index.md
+++ b/docs/Hardware/Tutorials/Electronics/Part4/Resistance/index.md
@@ -12,7 +12,7 @@ Some materials let electrons flow in a moderate manner. They are neither excelle
 
 Resistors are probably the most commonly used component in circuits. In fact, resistors can be found in nearly all practical circuits and have a multitude of uses.
 
-When prototyping, the most commonly used resistors are axial-lead resistors that have a wire coming out of each end and are [color coded](/Hardware/Reference/Components/Resistors/Reading) which specifies the amount of resistance that they have:
+When prototyping, the most commonly used resistors are axial-lead resistors that have a wire coming out of each end and are [color coded](/Hardware/Circuits/Components/Resistors/Reading) which specifies the amount of resistance that they have:
 
 ![Picture of a few axial lead resistors, each with a central cylinder and wires protruding from either end.](../Support_Files/Standard_Coaxial_Resistors.svg){:standalone}
 

--- a/docs/Hardware/Tutorials/Electronics/Part4/Review/index.md
+++ b/docs/Hardware/Tutorials/Electronics/Part4/Review/index.md
@@ -22,7 +22,7 @@ We're going to dive deeper into resistors and resistor networks later, but:
  * Resistors wired in _series_ (end-to-end) have a total resistance which is the sum of the resistance of each resistor.
  * _Conductance_ is the reciprocal of resistance, `(1/R)`, and is measured in siemens (S), but most often abbreviated as `G`.
  * Resistors wired in _parallel_ have a total resistance which is the sum of the conductance (in siemens) of each resistor, and then converted back to resistance.
- * Axial resistors are color coded to aid in identifying them. See [this chart](/Hardware/Reference/Components/Resistors/Reading/) for reference.
+ * Axial resistors are color coded to aid in identifying them. See [this chart](/Hardware/Circuits/Components/Resistors/Reading/) for reference.
  * Resistors have a tolerance which specifies a range that their actual resistance falls into.
  * Resistors come in a set of values that covers the range of possible values, adjusted for tolerance, with only small overlap.
  * _Breadboards_ reduce prototyping complexity by allowing you to create circuits without soldering.

--- a/docs/Hardware/Tutorials/Electronics/Part6/LEDs/index.md
+++ b/docs/Hardware/Tutorials/Electronics/Part6/LEDs/index.md
@@ -9,7 +9,7 @@ subtitle: Light Emitting Diodes.
 LEDs come in a variety of packages and combinations. Many packages have an arrangement of multiple LEDs in one, such as bar graphs and _7 segment_ displays that are often used to show levels or digit characters.
 
 <!-- MarkT: commented out, this is a broken link 
-![](/Hardware/Reference/Components/LEDs/SomeLEDs.jpg){:standalone}
+![](/Hardware/Circuits/Components/LEDs/SomeLEDs.jpg){:standalone}
 -->
 
 Regardless of what they look like, they're all basically the same to use. There are only two practical circuit concerns: making sure the _polarity_ is correct and limiting the current through them so they don't burn out.

--- a/docs/Hardware/index.md
+++ b/docs/Hardware/index.md
@@ -12,14 +12,14 @@ This section is a reference guide to common hardware and circuit information. Pl
 
 Contains various core component information.
 
- * [Surface Mount Device Packages and Sizes](/Hardware/Reference/Components/Packages_and_Sizes)
- * [Capacitors](/Hardware/Reference/Components/Capacitors)
- * [Diodes](/Hardware/Reference/Components/Diodes)
- * [LEDs](/Hardware/Reference/Components/LEDs)
-   * [Driving an LED with a PWM Signal](/Hardware/Reference/Components/LEDs/Driving_w_PWM/)
-   * [Driving an LED with a resistor](/Hardware/Reference/Components/LEDs/Driving_w_Resistor/)
- * [Resistors](/Hardware/Reference/Components/Resistors)
-   * [Reading a Resistor's Value](/Hardware/Reference/Components/Resistors/Reading)
+ * [Surface Mount Device Packages and Sizes](/Hardware/Circuits/Components/Packages_and_Sizes)
+ * [Capacitors](/Hardware/Circuits/Components/Capacitors)
+ * [Diodes](/Hardware/Circuits/Components/Diodes)
+ * [LEDs](/Hardware/Circuits/Components/LEDs)
+   * [Driving an LED with a PWM Signal](/Hardware/Circuits/Components/LEDs/Driving_w_PWM/)
+   * [Driving an LED with a resistor](/Hardware/Circuits/Components/LEDs/Driving_w_Resistor/)
+ * [Resistors](/Hardware/Circuits/Components/Resistors)
+   * [Reading a Resistor's Value](/Hardware/Circuits/Components/Resistors/Reading)
 
 ## Equations and Laws
 

--- a/docs/Netduino/Input_Output/Digital/I2C/Reading/index.md
+++ b/docs/Netduino/Input_Output/Digital/I2C/Reading/index.md
@@ -183,6 +183,6 @@ The next section of this guide will reconfigure the TMP102 temperature sensor by
 ## Further Information
 
 * [This Wikipedia article](https://en.wikipedia.org/wiki/I%C2%B2C) contains a description of the protocol, the various modes and the bus characteristics.
-* [Pull up resistors](/Hardware/Reference/Components/Resistors/PullUpAndPullDownResistors/)
+* [Pull up resistors](/Hardware/Circuits/Components/Resistors/PullUpAndPullDownResistors/)
 * [Effects of Varying I2C Pull-Up Resistor (external link)](http://dsscircuits.com/articles/effects-of-varying-i2c-pull-up-resistors)
 * [Netduino.Foundation `I2CBus`](http://netduino.foundation/API/Devices/Netduino/I2CBus/)

--- a/docs/Netduino/Input_Output/Digital/I2C/Writing/index.md
+++ b/docs/Netduino/Input_Output/Digital/I2C/Writing/index.md
@@ -324,6 +324,6 @@ Temperature data: 0x0c, 0xb1
 ## Further Information
 
 * [This Wikipedia article](https://en.wikipedia.org/wiki/I%C2%B2C) contains a description of the protocol, the various modes and the bus characteristics.
-* [Pull up resistors](/Hardware/Reference/Components/Resistors/PullUpAndPullDownResistors/)
+* [Pull up resistors](/Hardware/Circuits/Components/Resistors/PullUpAndPullDownResistors/)
 * [Effects of Varying I2C Pull-Up Resistor (external link)](http://dsscircuits.com/articles/effects-of-varying-i2c-pull-up-resistors)
 * [Netduino.Foundation `I2CBus`](http://netduino.foundation/API/Devices/Netduino/I2CBus/)

--- a/docs/Netduino/Input_Output/Digital/I2C/index.md
+++ b/docs/Netduino/Input_Output/Digital/I2C/index.md
@@ -30,7 +30,7 @@ In this circuit:
 * Each slave device has an address.  This allows the master device to choose which of the slaves it is communicating with
 * The two signal (bus) wires used are usually labelled `SDA` (Data) and `SCL` (Clock)
 * `SDA` and `SCL` are common to all devices on the bus
-* `SDA` and `SCL` are [open drain outputs](https://en.wikipedia.org/wiki/Open_collector) and so require [pull up resistors](/Hardware/Reference/Components/Resistors/PullUpAndPullDownResistors/) to connect the two lines to V<sub>cc</sub>
+* `SDA` and `SCL` are [open drain outputs](https://en.wikipedia.org/wiki/Open_collector) and so require [pull up resistors](/Hardware/Circuits/Components/Resistors/PullUpAndPullDownResistors/) to connect the two lines to V<sub>cc</sub>
 
 I2C is normally used to connect low speed devices over short distances.  Compare this to the main characteristics of [SPI](../SPI/) and [Serial](../UART) communications:
 
@@ -107,7 +107,7 @@ In addition to the 7 address bits, the master device will also send a single bit
 
 ### Pull-up Resistors
 
-Both of the bus lines (`SDA` and `SCL`) require [pull up resistors](/Hardware/Reference/Components/Resistors/PullUpAndPullDownResistors/) to be connected to them.  The value of the pull-up resistor will depend upon the capacitance of the bus.  The number of components on the board, type of substrate used will all influence the bus capacitance.
+Both of the bus lines (`SDA` and `SCL`) require [pull up resistors](/Hardware/Circuits/Components/Resistors/PullUpAndPullDownResistors/) to be connected to them.  The value of the pull-up resistor will depend upon the capacitance of the bus.  The number of components on the board, type of substrate used will all influence the bus capacitance.
 
 Most I2C breakout boards are supplied with pull-up resistors already on the breakout board.  In the case where one is not supplied, then a 4.7 K&Omega; resistor is usually good enough for prototyping.
 
@@ -130,6 +130,6 @@ For an in-depth discussion on writing data, see the [writing to I2C guide](Writi
 ## Further Information
 
 * [This Wikipedia article](https://en.wikipedia.org/wiki/I%C2%B2C) contains a description of the protocol, the various modes and the bus characteristics.
-* [Pull up resistors](/Hardware/Reference/Components/Resistors/PullUpAndPullDownResistors/)
+* [Pull up resistors](/Hardware/Circuits/Components/Resistors/PullUpAndPullDownResistors/)
 * [Effects of Varying I2C Pull-Up Resistor (external link)](http://dsscircuits.com/articles/effects-of-varying-i2c-pull-up-resistors)
 * [Netduino.Foundation `I2CBus`](http://netduino.foundation/API/Devices/Netduino/I2CBus/)

--- a/docs/Netduino/Input_Output/Digital/PWM/index.md
+++ b/docs/Netduino/Input_Output/Digital/PWM/index.md
@@ -79,7 +79,7 @@ The multimeter shows the average reading is 0.332V (10% of the output voltage of
 
 ### Changing the Brightness of an LED
 
-One of the most visible uses of PWM is to [control the brightness of an LED](/Hardware/Reference/Components/LEDs/Driving_w_PWM/).  A low duty cycle results in a dim LED, a higher duty cycle produces a brighter LED.
+One of the most visible uses of PWM is to [control the brightness of an LED](/Hardware/Circuits/Components/LEDs/Driving_w_PWM/).  A low duty cycle results in a dim LED, a higher duty cycle produces a brighter LED.
 
 ## Controlling a Servo
 

--- a/docs/Netduino/Input_Output/Digital/SPI/Writing/index.md
+++ b/docs/Netduino/Input_Output/Digital/SPI/Writing/index.md
@@ -119,7 +119,7 @@ As noted, the backpack allows the Netduino to talk to the LCD using SPI.  This r
 
 ### Software
 
-The MicroLiquidCrystal library allows a number of different way to connect to an LCD display.  The mechanism used is defined by a _Transfer Provider_.  In the cas of the [Adafruit LCD Backpack](https://www.adafruit.com/product/292) this is a [74595 shift register](/Hardware/Reference/Components/ShiftRegister74595).  This register takes 8 data bits transmitted serially (using SPI) and presents them to the display as 8 parallel data bits.
+The MicroLiquidCrystal library allows a number of different way to connect to an LCD display.  The mechanism used is defined by a _Transfer Provider_.  In the cas of the [Adafruit LCD Backpack](https://www.adafruit.com/product/292) this is a [74595 shift register](/Hardware/Circuits/Components/ShiftRegister74595).  This register takes 8 data bits transmitted serially (using SPI) and presents them to the display as 8 parallel data bits.
 
 The first section of code sets up the transport provider interface:
 
@@ -183,4 +183,4 @@ The next section  of the guide on SPI will demonstrate how to read data from an 
 * [Serial Peripheral Interface Bus](https://en.wikipedia.org/wiki/Serial_Peripheral_Interface_Bus) on Wikipedia.
 * [HD44780 LCD Interface](https://en.wikipedia.org/wiki/Hitachi_HD44780_LCD_controller) This is a common interface used to drive LCD displays.
 * [Adafruit I2C/ SPI Character LCD Backpack](https://www.adafruit.com/product/292)
-* [74595 shift register](/Hardware/Reference/Components/ShiftRegister74595)
+* [74595 shift register](/Hardware/Circuits/Components/ShiftRegister74595)

--- a/docs/Samples/Netduino/RGB_Blinky/index.md
+++ b/docs/Samples/Netduino/RGB_Blinky/index.md
@@ -15,7 +15,7 @@ The forward voltage on the LED is:
 
 And a current draw of 20mA for each color.
 
-Using the RGB calculation described [here](/Hardware/Reference/Components/LEDs/Driving_w_Resistor/), we get the following voltage drops:
+Using the RGB calculation described [here](/Hardware/Circuits/Components/LEDs/Driving_w_Resistor/), we get the following voltage drops:
 
 ```
 3.3V - 2.2V (red) = 1.1V

--- a/docs/_includes/HardwareNavigation.html
+++ b/docs/_includes/HardwareNavigation.html
@@ -54,8 +54,8 @@
     <ul>
         <li><a href="/Hardware/Circuits/Integrating_Meadow//Hardware/Circuits/Integrating_Meadow">Integrating Meadow</a>
             <ul>
-                <li><a href="/Hardware/Integrating_Meadow/F/Hardware/Circuits/Integrating_Meadow/F7_Micro">F7 Dev Module</a></li>
-                <li><a href="/Hardware/Integrating_Meadow/F/Hardware/Circuits/Integrating_Meadow/F7_Core-Compute">F7 Core-Compute Module</a>
+                <li><a href="/Hardware/Integrating_Meadow/F7/Hardware/Circuits/Integrating_Meadow/F7_Micro">F7 Dev Module</a></li>
+                <li><a href="/Hardware/Integrating_Meadow/F7/Hardware/Circuits/Integrating_Meadow/F7_Core-Compute">F7 Core-Compute Module</a>
                     <ul>USB</ul>
                     <ul>DFU</ul>
                 </li>


### PR DESCRIPTION
Should fix #484 

There was a restructuring that didn't get accounting in the existing URLs. This should update to that.

/Hardware/Reference/Components
...moved to...
/Hardware/Circuits/Components

There may be others that need fixing from that [same commit](https://github.com/WildernessLabs/Documentation/commit/5f31b0170b4954120b242ddf9b6596c385e1b64f).