### PR TITLE
Repair broken img tag and add alt text

### DIFF
--- a/docfx/api-override/Meadow.Foundation/Meadow.Foundation.Leds.Led.md
+++ b/docfx/api-override/Meadow.Foundation/Meadow.Foundation.Leds.Led.md
@@ -124,4 +124,4 @@ public override async Task Run()
 
 ### Wiring Example
 
-<img src="../../API_Assets/Meadow.Foundation.Leds.Led/Led_Fritzing.svg" 
+<img src="../../API_Assets/Meadow.Foundation.Leds.Led/Led_Fritzing.svg" alt="Circuit layout sample showing an LED connected through a resistor to pin D08 and ground on a Meadow F7." style="width: 60%; display: block; margin-left: auto; margin-right: auto;" />


### PR DESCRIPTION
Fixes #461

I restored the deleted markup that was accidentally removed and added new alt text.