### PR TITLE
Initial staticwebapp.config.json

### DIFF
--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -1,0 +1,8 @@
+{
+  "trailingSlash": "auto",
+  "responseOverrides": {
+    "404": {
+      "rewrite": "/index.html"
+    }
+  }
+}


### PR DESCRIPTION
Testing the [Azure Static Web App configuration](https://learn.microsoft.com/en-us/azure/static-web-apps/configuration) setup for 404 redirects and trailing slash use.