### PR TITLE
HelloPulsy docs inaccurate for F7FeatherV1 (Issue #480)

### DIFF
--- a/docs/Meadow/Meadow.Foundation/Getting_Started/index.md
+++ b/docs/Meadow/Meadow.Foundation/Getting_Started/index.md
@@ -26,7 +26,7 @@ namespace HelloPulsy
 
         public override Task Initialize()
         {
-            pwmLed = new PwmLed(Device, Device.Pins.D13, TypicalForwardVoltage.Blue);
+            pwmLed = new PwmLed(Device.Pins.D13, TypicalForwardVoltage.Blue);
             return base.Initialize();
         }
 


### PR DESCRIPTION
Removed `Device` parameter.

> This appears to be legacy from when we required the `Device` parameter. That's now handled for us, so we just need to remove that parameter entirely.