### PR TITLE
Removed the link Mapple Server

### DIFF
--- a/docs/Meadow/Meadow.OS/Networking/index.md
+++ b/docs/Meadow/Meadow.OS/Networking/index.md
@@ -181,7 +181,7 @@ For more information on getting the current antenna information and switching, s
 
 # Creating RESTful Web APIs with Maple Server
 
-If you need to expose simple RESTful Web APIs, Meadow.Foundation includes a lightweight web server called [Maple Server](../../Meadow.Foundation/Libraries_and_Frameworks/Maple.Server/index.md) that may be useful. Check out the [Maple Server guide](/Meadow/Meadow.Foundation/Libraries_and_Frameworks/Maple.Server/) for more information.
+If you need to expose simple RESTful Web APIs, Meadow.Foundation includes a lightweight web server called `Maple Server` that may be useful. Check out the [Maple Server guide](/Meadow/Meadow.Foundation/Libraries_and_Frameworks/Maple.Server/) for more information.
 
 # Sample projects
 


### PR DESCRIPTION
Removing the link` Mapple Server` which pointed to Meadow.Foundation Docs, but since the link right is correct we can remove it.