### PR TITLE
Fix link and add missing content

### DIFF
--- a/docs/Hardware/Reference/Components/Common/index.md
+++ b/docs/Hardware/Reference/Components/Common/index.md
@@ -2,3 +2,10 @@
 layout: Hardware
 title: Common Components
 ---
+
+This section covers common components used in circuits.
+
+* [Capacitors](Capacitors)
+* [Diodes](Diodes)
+* [Resistors](Resistors)
+* [Transistors](Transistors)

--- a/docs/Hardware/Reference/Components/index.md
+++ b/docs/Hardware/Reference/Components/index.md
@@ -5,5 +5,5 @@ title: Components
 
 This section covers the components that make up circuits.
 
-* [Common Components](Common_Components)
+* [Common](Common_Components)
 * [SMD Packages](Packages_and_Sizes)

--- a/docs/Hardware/Reference/Components/index.md
+++ b/docs/Hardware/Reference/Components/index.md
@@ -5,5 +5,5 @@ title: Components
 
 This section covers the components that make up circuits.
 
-* [Common](Common_Components)
+* [Common Components](Common)
 * [SMD Packages](Packages_and_Sizes)


### PR DESCRIPTION
{Fixes #732}
The original link is a 404.
The new link that reflects the page structure was an empty page.
So, I added the basic links to sub-sections as well.