### PR TITLE
Update getting-started link

### DIFF
--- a/docs/Meadow/Meadow.Foundation/Getting_Started/index.md
+++ b/docs/Meadow/Meadow.Foundation/Getting_Started/index.md
@@ -6,7 +6,7 @@ subtitle: Meadow.Foundation
 
 ## Hello, World!
 
-1. [Configure your Meadow development environment](../../Getting_Started/MCUs/F7_Feather/index.md).
+1. [Configure your Meadow development environment](../../Getting_Started/index.md).
 1. Create a new C# Meadow Application project, name it `HelloPulsy`.
 1. Plug the longer leg (anode) of a blue LED into pin `13` and the other leg into `GND`:
 


### PR DESCRIPTION
{fixes #586}

The old link went to the Feather getting-started. This goes to the general getting started section.