### PR TITLE
Digital IO Docs

### DIFF
--- a/docs/Meadow/Meadow_Basics/IO/Digital/index.md
+++ b/docs/Meadow/Meadow_Basics/IO/Digital/index.md
@@ -57,7 +57,7 @@ IDigitalInputPort CreateDigitalInputPort(
     ResistorMode resistorMode = ResistorMode.Disabled);
 ```
 
-The three most important arguments are:
+The arguments are:
 
 * **`pin`** - The pin on the device of which to configure to be a digital input.
 * **`resistorMode`** - The `ResistorMode` specifying whether an external pull-up/pull-down resistor is used, or an internal pull-up/pull-down resistor should be configured for default state.

--- a/docs/Meadow/Meadow_Basics/IO/Digital/index.md
+++ b/docs/Meadow/Meadow_Basics/IO/Digital/index.md
@@ -60,7 +60,6 @@ IDigitalInputPort CreateDigitalInputPort(
 The three most important arguments are:
 
 * **`pin`** - The pin on the device of which to configure to be a digital input.
-* **`interruptMode`** - Whether or not the port should be configured to raise interrupt notifications, and what kind of change should trigger an interrupt.
 * **`resistorMode`** - The `ResistorMode` specifying whether an external pull-up/pull-down resistor is used, or an internal pull-up/pull-down resistor should be configured for default state.
 
 We'll examine debounce and glitch filtering in a moment.

--- a/docs/Meadow/Meadow_Basics/IO/Digital/index.md
+++ b/docs/Meadow/Meadow_Basics/IO/Digital/index.md
@@ -54,10 +54,7 @@ _Reading_ the state of a _digital input_ is done using an implementation of the 
 ```csharp
 IDigitalInputPort CreateDigitalInputPort(
     IPin pin,
-    InterruptMode interruptMode = InterruptMode.None,
-    ResistorMode resistorMode = ResistorMode.Disabled,
-    double debounceDuration = 0,
-    double glitchDuration = 0);
+    ResistorMode resistorMode = ResistorMode.Disabled);
 ```
 
 The three most important arguments are:
@@ -94,7 +91,10 @@ For example, if you wanted your application to get notified when the `D03` input
 // create the InputPort with interrupts enabled
 var input = Device.CreateDigitalInputPort(
     Device.Pins.D03,
-    InterruptMode.EdgeRising);
+    InterruptMode.EdgeRising,
+    ResistorMode.Disabled,
+    TimeSpan.FromMilliseconds(5),
+    TimeSpan.FromMilliseconds(5));
 
 // add an event handler
 input.Changed += (s, e) =>


### PR DESCRIPTION
Updated CreateDigitalInterruptPort and CreateDigitalInputPort.

CreateDigitalInputPort previously included parameters for CreateDigitalInterruptPort.

Note that there is still an ambiguity in Glitch and Debounce filters as it states '0' to disable. Should this be 'TimeSpan.Zero'?