### PR TITLE
Minor fix on Ethernet config sample

### DIFF
--- a/docs/Meadow/Meadow.OS/Networking/index.md
+++ b/docs/Meadow/Meadow.OS/Networking/index.md
@@ -124,17 +124,17 @@ If you're using an [Dual, Switching Ethernet Add-on module](https://store.wilder
 Network:
   Interfaces:
     - Name: Ethernet
-      UseDHCP: false
-      IPAddress: 192.168.1.60
-      NetMask: 255.255.255.0
-      Gateway: 192.168.1.254
-#    - Name: Ethernet
-#      UseDHCP: true
+      UseDHCP: true
+      # IPAddress: 192.168.1.60
+      # NetMask: 255.255.255.0
+      # Gateway: 192.168.1.254
 
   DefaultInterface: Ethernet
 ...
 ```
-Optionally you can set the `UseDHCP: true` to get an IP Address automatically. If `DefaultInterface` is not set on the config file, it will default to WiFi.
+Optionally you can set the `UseDHCP: false` to use an static IP Address, in this case, please configure your `IpAddress`, `NetMask`, and `Gateway` correctly, ensuring the `IPAddress` is within your local network and not already in use.
+
+ If `DefaultInterface` is not set on the config file, it will default to WiFi.
 
 
   </TabItem>

--- a/docs/Meadow/Meadow.OS/Networking/index.md
+++ b/docs/Meadow/Meadow.OS/Networking/index.md
@@ -132,9 +132,9 @@ Network:
   DefaultInterface: Ethernet
 ...
 ```
-Optionally you can set the `UseDHCP: false` to use an static IP Address, in this case, please configure your `IpAddress`, `NetMask`, and `Gateway` correctly, ensuring the `IPAddress` is within your local network and not already in use.
+Optionally you can set the `UseDHCP: false` to use an static IP Address. In this case, please configure your `IpAddress`, `NetMask`, and `Gateway` correctly, ensuring the `IPAddress` is within your local network and not already in use.
 
- If `DefaultInterface` is not set on the config file, it will default to WiFi.
+If `DefaultInterface` is not set on the config file, it will default to WiFi.
 
 
   </TabItem>


### PR DESCRIPTION
- https://github.com/WildernessLabs/Meadow_Issues/issues/725

Many users seem to use the same config as in the documentation, but forget to properly set the IP address, since using a static IP address is a bit more complicated - you need to find your gateway, netmask, and choose an IP address within your local network that is not currently already in use. 

For this reason, I believe that would be easier for the new user trying to use ethernet, to use the DHCP, since the user doesn't need to take all of it into consideration, given that the DHCP will set everything automatically.