### PR TITLE
Updated docs for automatic OtA

### DIFF
--- a/docs/Meadow/Meadow.Cloud/OtA_Updates/index.md
+++ b/docs/Meadow/Meadow.Cloud/OtA_Updates/index.md
@@ -99,7 +99,7 @@ public override async Task Run()
 }
 ```
 
-This code adds event handlers to monitor state changes during the update process (`StateChanged`), get download progress info (`RetrieveProgress`), download the new package, `updateService.RetrieveUpdate(info)`. and send the new file(s) to the bootloader, `updateService.ApplyUpdate(info)`.
+This code adds event handlers to monitor state changes during the update process (`StateChanged`), get download progress info (`RetrieveProgress`), download the new package (`updateService.RetrieveUpdate(info)`), and send the new file(s) to the bootloader (`updateService.ApplyUpdate(info)`).
 
 Additionally, you can also monitor State changes on a Meadow.Cloud connection
 

--- a/docs/Meadow/Meadow.Cloud/OtA_Updates/index.md
+++ b/docs/Meadow/Meadow.Cloud/OtA_Updates/index.md
@@ -53,7 +53,7 @@ You can, optionally, tie into the update notification to either cancel an update
 
 For example, the following code listens for an update and manually applies it:
 
- ```csharp
+```csharp
 using Meadow.Update;
 ...
 public override async Task Run()

--- a/docs/Meadow/Meadow.Cloud/OtA_Updates/index.md
+++ b/docs/Meadow/Meadow.Cloud/OtA_Updates/index.md
@@ -10,7 +10,7 @@ Meadow.Cloud provides secure, automatic, Over-the-Air (OtA) updates, which enabl
 
 ### Opt-out Model
 
-OtA updates in Meadow follow an opt-out model, in the sense that if a device is provisioned with Meadow.Cloud, and OtA updates are set to `true` in its configuration file, an update that is pushed to the device from Meadow.Cloud will automatically install upon receipt fo notification, unless the application chooses not to install it.
+OtA updates in Meadow follow an opt-out model, in the sense that if a device is provisioned with Meadow.Cloud, and OtA updates are set to `true` in its configuration file, an update that is pushed to the device from Meadow.Cloud will automatically install upon receipt of notification, unless the application chooses not to install it.
 
 ### Sending an OtA Update
 

--- a/docs/Meadow/Meadow.Cloud/OtA_Updates/index.md
+++ b/docs/Meadow/Meadow.Cloud/OtA_Updates/index.md
@@ -6,15 +6,26 @@ subtitle: Getting started with OtA
 
 ## Overview
 
-Meadow.Cloud provides secure, Over-the-Air (OtA) updates, which enable you to push a new version of a Meadow application to a device in the field over the network.
+Meadow.Cloud provides secure, automatic, Over-the-Air (OtA) updates, which enable you to push a new versions of Meadow.OS, Meadow applications, or even a config change to a device in the field over its configured network.
 
-To get OtA setup you need to first [provision your device](/Meadow/Meadow.Cloud/Device_Provisioning/). Then, you need to package an application that enables the _Update Service_ and upload it to Meadow.Cloud. Finally, you can publish your package to be received by your devices.
+### Opt-out Model
+
+OtA updates in Meadow follow an opt-out model, in the sense that if a device is provisioned with Meadow.Cloud, and OtA updates are set to `true` in its configuration file, an update that is pushed to the device from Meadow.Cloud will automatically install upon receipt fo notification, unless the application chooses not to install it.
+
+### Sending an OtA Update
+
+To send an update to a device, you must do the following:
+
+1. **[Provision the device in Meadow.Cloud](/Meadow/Meadow.Cloud/Device_Provisioning/)** - 
+To enable OtA updates (and other Meadow.Cloud integrations such as crash-reporting, command + control, etc.) you need to first [provision your device](/Meadow/Meadow.Cloud/Device_Provisioning/). 
+2. **Enable Meadow.Cloud in Config** - Meadow.Cloud and OtA updates must both be enabled in the `app.config.yaml` file.
+3. **Create an .MPAK and Push from Meadow.Cloud** - Updates are packaged in *Meadow Package Files* (.MPAKs) using the Meadow.CLI and then uploaded to Meadow.Cloud and sent to *Device Collections*. This process is also [optionally automatable via GitHub Actions](/Meadow/Meadow.Cloud/CI_CD/), so you can integrate updates into your Devops workflow.
 
 :::caution
 OtA Updates are not available for Meadow Feather F7 v1 boards due to memory limitations. However, we're currently working on implementing mechanisms to make update sizes much smaller so we can make the download process faster and support more devices with limited resources.
 :::
 
-## Enable Update Service in Meadow.Core
+## Enabling Meadow.Cloud + Updates in `app.config.yaml`
 
 By default, OtA is not enabled. Follow the steps to enable OtA in your application.
 
@@ -34,72 +45,78 @@ By default, OtA is not enabled. Follow the steps to enable OtA in your applicati
                 Default: "Trace"
         ```
 
-1. Next, add event handlers for monitoring, downloading, checking download progress and applying the updates.
+As long as your device has an internet connection, it'll automatically apply updates as they're received.
 
-    ```csharp
-    using Meadow.Update;
-    ...
-    public override async Task Run()
+## Optionally Tying into Update Events
+
+You can, optionally, tie into the update notification to either cancel an update, or apply it later. 
+
+For example, the following code listens for an update and manually applies it:
+
+ ```csharp
+using Meadow.Update;
+...
+public override async Task Run()
+{
+    var svc = Resolver.UpdateService;
+    
+    // Uncomment to clear any persisted update info. This allows installing 
+    // the same update multiple times, such as you might do during development.
+    // svc.ClearUpdates();
+
+    svc.StateChanged += (sender, updateState) =>
     {
-        var svc = Resolver.UpdateService;
-        
-        // Uncomment to clear any persisted update info. This allows installing 
-        // the same update multiple times, such as you might do during development.
-        // svc.ClearUpdates();
+        Resolver.Log.Info($"UpdateState {updateState}");
+    };
 
-        svc.StateChanged += (sender, updateState) =>
-        {
-            Resolver.Log.Info($"UpdateState {updateState}");
-        };
-
-        svc.RetrieveProgress += (updateService, info) =>
-        {
-            short percentage = (short)((double)info.DownloadProgress / info.FileSize * 100);
-
-            Resolver.Log.Info($"Downloading... {percentage}%");
-        };
-
-        svc.UpdateAvailable += async (updateService, info) =>
-        {
-            Resolver.Log.Info($"Update available!");
-
-            // Queue update for retrieval "later"
-            await Task.Delay(5000);
-
-            updateService.RetrieveUpdate(info);
-        };
-
-        svc.UpdateRetrieved += async (updateService, info) =>
-        {
-            Resolver.Log.Info($"Update retrieved!");
-
-            await Task.Delay(5000);
-
-            updateService.ApplyUpdate(info);
-        };
-        ...
-
-    }
-    ```
-
-    This code adds event handlers to monitor state changes during the update process (`StateChanged`), get download progress info (`RetrieveProgress`), download the new package, `updateService.RetrieveUpdate(info)`. and send the new file(s) to the bootloader, `updateService.ApplyUpdate(info)`.
-
-    Additionally, you can also monitor State changes on a Meadow.Cloud connection
-
-    ```csharp
-    ...
-    var cloudService = Resolver.MeadowCloudService;
-
-    cloudService.ConnectionStateChanged += (sender, cloudConnectionState) =>
+    svc.RetrieveProgress += (updateService, info) =>
     {
-        Resolver.Log.Info($"CloudConnectionState: {cloudConnectionState}");
+        short percentage = (short)((double)info.DownloadProgress / info.FileSize * 100);
+
+        Resolver.Log.Info($"Downloading... {percentage}%");
+    };
+
+    svc.UpdateAvailable += async (updateService, info) =>
+    {
+        Resolver.Log.Info($"Update available!");
+
+        // Queue update for retrieval "later"
+        await Task.Delay(5000);
+
+        updateService.RetrieveUpdate(info);
+    };
+
+    svc.UpdateRetrieved += async (updateService, info) =>
+    {
+        Resolver.Log.Info($"Update retrieved!");
+
+        await Task.Delay(5000);
+
+        updateService.ApplyUpdate(info);
     };
     ...
-    ```
+
+}
+```
+
+This code adds event handlers to monitor state changes during the update process (`StateChanged`), get download progress info (`RetrieveProgress`), download the new package, `updateService.RetrieveUpdate(info)`. and send the new file(s) to the bootloader, `updateService.ApplyUpdate(info)`.
+
+Additionally, you can also monitor State changes on a Meadow.Cloud connection
+
+```csharp
+...
+var cloudService = Resolver.MeadowCloudService;
+
+cloudService.ConnectionStateChanged += (sender, cloudConnectionState) =>
+{
+    Resolver.Log.Info($"CloudConnectionState: {cloudConnectionState}");
+};
+...
+```
 
 ## MPAK Creation
 
-An .mpak file is an application bundle. We'll use the application we created in the previous section.
+To build an `.mpak` update file, follow the instructions below:
 
 1. Create your MPAK with the Meadow CLI, replacing `[target Meadow OS version]` with your target Meadow OS version (such as `1.10.0.2`) and give whatever name you want to provide.
 
@@ -116,7 +133,7 @@ An .mpak file is an application bundle. We'll use the application we created in 
 
 1. Visit [https://www.meadowcloud.co/my/packages](https://www.meadowcloud.co/my/packages) to verify your package was successfully uploaded.
 
-## Publish
+## Publishing
 
 * To publish via CLI, run `meadow cloud package publish <your_package_id> -c <id of the collection>`.
 * To publish via Web, go to [https://www.meadowcloud.co/my/packages](https://www.meadowcloud.co/my/packages) and click **Publish**.


### PR DESCRIPTION
manual tie-in code should still be looked at to show either cancelling the update, or scheduling it for later.